### PR TITLE
Add BPE-aware chunking helpers for byte-level tokenizers

### DIFF
--- a/SentenceTransformers.ArcticXs/src/SentenceEncoder.cs
+++ b/SentenceTransformers.ArcticXs/src/SentenceEncoder.cs
@@ -9,16 +9,31 @@ using SentenceTransformers;
 
 namespace SentenceTransformers.ArcticXs;
 
+/// <summary>
+/// Sentence encoder for the Snowflake arctic-embed-xs model. Loads the embedded ONNX model, tokenizes
+/// inputs through <see cref="ArcticTokenizer"/>, runs ONNX inference, and returns L2-normalized
+/// embeddings produced directly from the model's pooled output (no additional pooling is applied).
+/// Implements <see cref="ISentenceEncoder"/>, so the shared chunking helpers
+/// (<c>ChunkTokens</c>, <c>ChunkAndEncodeAsync</c>, <c>ChunkAndEncodeTaggedAsync</c>, and their aligned
+/// counterparts) are available on instances cast to that interface.
+/// </summary>
 public sealed class SentenceEncoder : IDisposable, ISentenceEncoder
 {
     private readonly SessionOptions   _sessionOptions;
     private readonly InferenceSession _session;
+
+    /// <summary>WordPiece tokenizer used to convert raw text into model input ids/attention/token-type tensors.</summary>
     public           TokenizerBase    Tokenizer { get; }
     private readonly string[]         _outputNames;
 
+    /// <summary>Maximum number of tokens the model can process per call (512 for arctic-embed-xs).</summary>
     public static int GetMaxChunkLength() => 512;
+
+    /// <inheritdoc cref="GetMaxChunkLength"/>
     public        int MaxChunkLength      => GetMaxChunkLength();
 
+    /// <summary>Creates a new encoder, loading the embedded ONNX model and the arctic-embed vocabulary.</summary>
+    /// <param name="sessionOptions">Optional ONNX runtime session options. A new default instance is used when null.</param>
     public SentenceEncoder(SessionOptions sessionOptions = null)
     {
         _sessionOptions = sessionOptions ?? new SessionOptions();
@@ -28,12 +43,21 @@ public sealed class SentenceEncoder : IDisposable, ISentenceEncoder
         _outputNames = _session.OutputMetadata.Keys.ToArray();
     }
 
+    /// <summary>Disposes the ONNX session and its options.</summary>
     public void Dispose()
     {
         _sessionOptions.Dispose();
         _session.Dispose();
     }
 
+    /// <summary>
+    /// Encodes a batch of sentences. Each sentence is tokenized and padded to the longest sequence
+    /// in the batch (truncated at <see cref="MaxChunkLength"/>), the model is run, and its output
+    /// vectors are L2-normalized.
+    /// </summary>
+    /// <param name="sentences">Texts to embed. Each entry produces one vector in the result.</param>
+    /// <param name="cancellationToken">Token used to terminate the ONNX run early.</param>
+    /// <returns>Array of embedding vectors, one per input sentence in the same order.</returns>
     public async Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default)
     {
         var numSentences = sentences.Length;

--- a/SentenceTransformers.Harrier/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier/src/SentenceEncoder.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using BERTTokenizers.Base;
+using SentenceTransformers;
 using static SentenceTransformers.Harrier.DenseTensorHelpers;
 
 namespace SentenceTransformers.Harrier
@@ -192,6 +193,74 @@ namespace SentenceTransformers.Harrier
                 throw;
             }
         }
+
+        /// <summary>
+        /// Tokenizes <paramref name="text"/> and merges tokens into chunks of at most
+        /// <paramref name="chunkLength"/> tokens with <paramref name="chunkOverlap"/> tokens of
+        /// overlap. Equivalent to the shared <see cref="ISentenceEncoder.ChunkTokens"/> helper,
+        /// surfaced as an instance method so callers do not need to cast to the interface.
+        /// </summary>
+        /// <param name="text">Source text to chunk.</param>
+        /// <param name="chunkLength">Maximum tokens per chunk.</param>
+        /// <param name="chunkOverlap">Tokens of overlap between consecutive chunks.</param>
+        /// <param name="maxChunks">Hard cap on the number of chunks returned.</param>
+        /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+        public List<string> ChunkTokens(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+            => ((ISentenceEncoder)this).ChunkTokens(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries offsets back into the
+        /// source text. Equivalent to <see cref="ISentenceEncoder.ChunkTokensAligned"/>.
+        /// </summary>
+        /// <inheritdoc cref="ChunkTokens"/>
+        public List<AlignedString> ChunkTokensAligned(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+            => ((ISentenceEncoder)this).ChunkTokensAligned(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+
+        /// <summary>
+        /// Splits <paramref name="text"/> into token-bounded chunks and encodes each chunk to an embedding.
+        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAsync"/>.
+        /// </summary>
+        /// <param name="text">Source text. May be longer than <see cref="MaxChunkLength"/>.</param>
+        /// <param name="chunkLength">Maximum tokens per chunk. Values <c>&lt;= 0</c> or above <see cref="MaxChunkLength"/> are clamped to <see cref="MaxChunkLength"/>.</param>
+        /// <param name="chunkOverlap">Tokens of overlap between consecutive chunks. Out-of-range values default to <c>chunkLength / 5</c>.</param>
+        /// <param name="sequentially">When true, encode chunks one-by-one; when false, encode in a single batched call.</param>
+        /// <param name="maxChunks">Hard cap on chunks produced.</param>
+        /// <param name="keepResultsOnCancellation">When true and cancelled, returns the chunks already encoded.</param>
+        /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public Task<EncodedChunk[]> ChunkAndEncodeAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkAndEncodeAsync"/>: results carry offsets back into
+        /// <paramref name="text"/>. Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAlignedAsync"/>.
+        /// </summary>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<EncodedChunkAligned[]> ChunkAndEncodeAlignedAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeAlignedAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Chunks <paramref name="text"/> on token boundaries, then for each chunk invokes
+        /// <paramref name="stripTags"/> to remove injected markers and recover a tag (for example,
+        /// page numbers extracted from markers like <c>⁎12⁑</c>) before encoding the cleaned text.
+        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAsync"/>.
+        /// </summary>
+        /// <param name="text">Source text with injected markers.</param>
+        /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/> (cleaned text + tag).</param>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<TaggedEncodedChunk[]> ChunkAndEncodeTaggedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkAndEncodeTaggedAsync"/>: each result carries offsets
+        /// into <paramref name="text"/> alongside the cleaned text, tag, and embedding.
+        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAlignedAsync"/>.
+        /// </summary>
+        /// <param name="text">Source text with injected markers.</param>
+        /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/>.</param>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<TaggedEncodedChunkAligned[]> ChunkAndEncodeTaggedAlignedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAlignedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         private List<NamedOnnxValue> BuildModelInputs(
             List<(long[] InputIds, long[] TokenTypeIds, long[] AttentionMask)> encoded,

--- a/SentenceTransformers.Harrier/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier/src/SentenceEncoder.cs
@@ -197,8 +197,10 @@ namespace SentenceTransformers.Harrier
         /// <summary>
         /// Tokenizes <paramref name="text"/> and merges tokens into chunks of at most
         /// <paramref name="chunkLength"/> tokens with <paramref name="chunkOverlap"/> tokens of
-        /// overlap. Equivalent to the shared <see cref="ISentenceEncoder.ChunkTokens"/> helper,
-        /// surfaced as an instance method so callers do not need to cast to the interface.
+        /// overlap. Each chunk's text is reconstructed by slicing the source between the first and
+        /// last token's offsets returned by the Hugging Face tokenizer, which preserves the exact
+        /// original whitespace and any injected markers. This is the BPE-appropriate replacement
+        /// for the WordPiece-oriented <see cref="ISentenceEncoder.ChunkTokens"/> default.
         /// </summary>
         /// <param name="text">Source text to chunk.</param>
         /// <param name="chunkLength">Maximum tokens per chunk.</param>
@@ -206,19 +208,19 @@ namespace SentenceTransformers.Harrier
         /// <param name="maxChunks">Hard cap on the number of chunks returned.</param>
         /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
         public List<string> ChunkTokens(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
-            => ((ISentenceEncoder)this).ChunkTokens(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+            => BPEChunkAndEncodeHelpers.ChunkTokens(Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress);
 
         /// <summary>
-        /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries offsets back into the
-        /// source text. Equivalent to <see cref="ISentenceEncoder.ChunkTokensAligned"/>.
+        /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries offsets back into
+        /// <paramref name="text"/>.
         /// </summary>
         /// <inheritdoc cref="ChunkTokens"/>
         public List<AlignedString> ChunkTokensAligned(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
-            => ((ISentenceEncoder)this).ChunkTokensAligned(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+            => BPEChunkAndEncodeHelpers.ChunkTokensAligned(Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress);
 
         /// <summary>
-        /// Splits <paramref name="text"/> into token-bounded chunks and encodes each chunk to an embedding.
-        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAsync"/>.
+        /// Splits <paramref name="text"/> into BPE-token-bounded chunks and encodes each chunk to
+        /// an embedding. Uses offset-based chunk reconstruction (see <see cref="ChunkTokens"/>).
         /// </summary>
         /// <param name="text">Source text. May be longer than <see cref="MaxChunkLength"/>.</param>
         /// <param name="chunkLength">Maximum tokens per chunk. Values <c>&lt;= 0</c> or above <see cref="MaxChunkLength"/> are clamped to <see cref="MaxChunkLength"/>.</param>
@@ -229,38 +231,36 @@ namespace SentenceTransformers.Harrier
         /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         public Task<EncodedChunk[]> ChunkAndEncodeAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeAsync(this, text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         /// <summary>
-        /// Aligned variant of <see cref="ChunkAndEncodeAsync"/>: results carry offsets back into
-        /// <paramref name="text"/>. Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAlignedAsync"/>.
+        /// Aligned variant of <see cref="ChunkAndEncodeAsync"/>: each result also carries offsets
+        /// back into <paramref name="text"/>.
         /// </summary>
         /// <inheritdoc cref="ChunkAndEncodeAsync"/>
         public Task<EncodedChunkAligned[]> ChunkAndEncodeAlignedAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeAlignedAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeAlignedAsync(this, text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         /// <summary>
-        /// Chunks <paramref name="text"/> on token boundaries, then for each chunk invokes
-        /// <paramref name="stripTags"/> to remove injected markers and recover a tag (for example,
-        /// page numbers extracted from markers like <c>⁎12⁑</c>) before encoding the cleaned text.
-        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAsync"/>.
+        /// Chunks <paramref name="text"/> using BPE offsets, then for each chunk runs
+        /// <paramref name="stripTags"/> to remove injected markers and recover a tag before
+        /// encoding the cleaned text. The chunker treats markers as ordinary tokens.
         /// </summary>
         /// <param name="text">Source text with injected markers.</param>
         /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/> (cleaned text + tag).</param>
         /// <inheritdoc cref="ChunkAndEncodeAsync"/>
         public Task<TaggedEncodedChunk[]> ChunkAndEncodeTaggedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAsync(this, text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         /// <summary>
         /// Aligned variant of <see cref="ChunkAndEncodeTaggedAsync"/>: each result carries offsets
         /// into <paramref name="text"/> alongside the cleaned text, tag, and embedding.
-        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAlignedAsync"/>.
         /// </summary>
         /// <param name="text">Source text with injected markers.</param>
-        /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/>.</param>
+        /// <param name="stripTags">Callback that strips markers from the original chunk substring and produces a <see cref="TaggedChunk"/>.</param>
         /// <inheritdoc cref="ChunkAndEncodeAsync"/>
         public Task<TaggedEncodedChunkAligned[]> ChunkAndEncodeTaggedAlignedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAlignedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAlignedAsync(this, text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         private List<NamedOnnxValue> BuildModelInputs(
             List<(long[] InputIds, long[] TokenTypeIds, long[] AttentionMask)> encoded,

--- a/SentenceTransformers.MiniLM/src/SentenceEncoder.cs
+++ b/SentenceTransformers.MiniLM/src/SentenceEncoder.cs
@@ -6,16 +6,35 @@ using SentenceTransformers;
 
 namespace SentenceTransformers.MiniLM;
 
+/// <summary>
+/// Sentence encoder for the all-MiniLM-L6-v2 model. Loads the embedded ONNX model, applies WordPiece
+/// tokenization through <see cref="MiniLMTokenizer"/>, runs the ONNX inference session, and returns
+/// 384-dimensional L2-normalized embeddings produced by mean-pooling the token outputs with the
+/// attention mask. Implements <see cref="ISentenceEncoder"/>, so the shared chunking helpers
+/// (<c>ChunkTokens</c>, <c>ChunkAndEncodeAsync</c>, <c>ChunkAndEncodeTaggedAsync</c>, and their aligned
+/// counterparts) are available on instances cast to that interface.
+/// </summary>
 public sealed class SentenceEncoder : IDisposable, ISentenceEncoder
 {
     private readonly SessionOptions   _sessionOptions;
     private readonly InferenceSession _session;
+
+    /// <summary>WordPiece tokenizer used to convert raw text into model input ids/attention/token-type tensors.</summary>
     public           TokenizerBase    Tokenizer { get; }
     private readonly string[]         _outputNames;
 
-    public static int GetMaxChunkLength() => 256; //The documentation is incorrect for MiniLM - the context window size is 256 - see https://stackoverflow.com/questions/75901231/max-seq-length-for-transformer-sentence-bert
+    /// <summary>
+    /// Maximum number of tokens the model can process per call.
+    /// MiniLM-L6-v2 is trained with a 256-token context window despite the often-quoted 512;
+    /// see https://stackoverflow.com/questions/75901231/max-seq-length-for-transformer-sentence-bert.
+    /// </summary>
+    public static int GetMaxChunkLength() => 256;
+
+    /// <inheritdoc cref="GetMaxChunkLength"/>
     public        int MaxChunkLength      => GetMaxChunkLength();
 
+    /// <summary>Creates a new encoder, loading the embedded ONNX model and the MiniLM vocabulary.</summary>
+    /// <param name="sessionOptions">Optional ONNX runtime session options. A new default instance is used when null.</param>
     public SentenceEncoder(SessionOptions sessionOptions = null)
     {
         _sessionOptions = sessionOptions ?? new SessionOptions();
@@ -25,12 +44,21 @@ public sealed class SentenceEncoder : IDisposable, ISentenceEncoder
         _outputNames = _session.OutputMetadata.Keys.ToArray();
     }
 
+    /// <summary>Disposes the ONNX session and its options.</summary>
     public void Dispose()
     {
         _sessionOptions.Dispose();
         _session.Dispose();
     }
 
+    /// <summary>
+    /// Encodes a batch of sentences to 384-dimensional embeddings. Each sentence is tokenized and
+    /// padded to the longest sequence in the batch (truncated at <see cref="MaxChunkLength"/>),
+    /// then mean-pooled with the attention mask and L2-normalized.
+    /// </summary>
+    /// <param name="sentences">Texts to embed. Each entry produces one vector in the result.</param>
+    /// <param name="cancellationToken">Token used to terminate the ONNX run early.</param>
+    /// <returns>Array of <c>float[384]</c> vectors, one per input sentence in the same order.</returns>
     public async Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default)
     {
         var numSentences = sentences.Length;

--- a/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using BERTTokenizers.Base;
+using SentenceTransformers;
 using static SentenceTransformers.Qwen3.DenseTensorHelpers;
 
 namespace SentenceTransformers.Qwen3
@@ -154,6 +155,74 @@ namespace SentenceTransformers.Qwen3
                 throw;
             }
         }
+
+        /// <summary>
+        /// Tokenizes <paramref name="text"/> and merges tokens into chunks of at most
+        /// <paramref name="chunkLength"/> tokens with <paramref name="chunkOverlap"/> tokens of
+        /// overlap. Equivalent to the shared <see cref="ISentenceEncoder.ChunkTokens"/> helper,
+        /// surfaced as an instance method so callers do not need to cast to the interface.
+        /// </summary>
+        /// <param name="text">Source text to chunk.</param>
+        /// <param name="chunkLength">Maximum tokens per chunk.</param>
+        /// <param name="chunkOverlap">Tokens of overlap between consecutive chunks.</param>
+        /// <param name="maxChunks">Hard cap on the number of chunks returned.</param>
+        /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+        public List<string> ChunkTokens(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+            => ((ISentenceEncoder)this).ChunkTokens(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries offsets back into the
+        /// source text. Equivalent to <see cref="ISentenceEncoder.ChunkTokensAligned"/>.
+        /// </summary>
+        /// <inheritdoc cref="ChunkTokens"/>
+        public List<AlignedString> ChunkTokensAligned(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+            => ((ISentenceEncoder)this).ChunkTokensAligned(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+
+        /// <summary>
+        /// Splits <paramref name="text"/> into token-bounded chunks and encodes each chunk to an embedding.
+        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAsync"/>.
+        /// </summary>
+        /// <param name="text">Source text. May be longer than <see cref="MaxChunkLength"/>.</param>
+        /// <param name="chunkLength">Maximum tokens per chunk. Values <c>&lt;= 0</c> or above <see cref="MaxChunkLength"/> are clamped to <see cref="MaxChunkLength"/>.</param>
+        /// <param name="chunkOverlap">Tokens of overlap between consecutive chunks. Out-of-range values default to <c>chunkLength / 5</c>.</param>
+        /// <param name="sequentially">When true, encode chunks one-by-one; when false, encode in a single batched call.</param>
+        /// <param name="maxChunks">Hard cap on chunks produced.</param>
+        /// <param name="keepResultsOnCancellation">When true and cancelled, returns the chunks already encoded.</param>
+        /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public Task<EncodedChunk[]> ChunkAndEncodeAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkAndEncodeAsync"/>: results carry offsets back into
+        /// <paramref name="text"/>. Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAlignedAsync"/>.
+        /// </summary>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<EncodedChunkAligned[]> ChunkAndEncodeAlignedAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeAlignedAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Chunks <paramref name="text"/> on token boundaries, then for each chunk invokes
+        /// <paramref name="stripTags"/> to remove injected markers and recover a tag (for example,
+        /// page numbers extracted from markers like <c>⁎12⁑</c>) before encoding the cleaned text.
+        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAsync"/>.
+        /// </summary>
+        /// <param name="text">Source text with injected markers.</param>
+        /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/> (cleaned text + tag).</param>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<TaggedEncodedChunk[]> ChunkAndEncodeTaggedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkAndEncodeTaggedAsync"/>: each result carries offsets
+        /// into <paramref name="text"/> alongside the cleaned text, tag, and embedding.
+        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAlignedAsync"/>.
+        /// </summary>
+        /// <param name="text">Source text with injected markers.</param>
+        /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/>.</param>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<TaggedEncodedChunkAligned[]> ChunkAndEncodeTaggedAlignedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAlignedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         private List<NamedOnnxValue> BuildModelInputs(
             List<(long[] InputIds, long[] TokenTypeIds, long[] AttentionMask)> encoded,

--- a/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
@@ -159,8 +159,10 @@ namespace SentenceTransformers.Qwen3
         /// <summary>
         /// Tokenizes <paramref name="text"/> and merges tokens into chunks of at most
         /// <paramref name="chunkLength"/> tokens with <paramref name="chunkOverlap"/> tokens of
-        /// overlap. Equivalent to the shared <see cref="ISentenceEncoder.ChunkTokens"/> helper,
-        /// surfaced as an instance method so callers do not need to cast to the interface.
+        /// overlap. Each chunk's text is reconstructed by slicing the source between the first and
+        /// last token's offsets returned by the Hugging Face tokenizer, which preserves the exact
+        /// original whitespace and any injected markers. This is the BPE-appropriate replacement
+        /// for the WordPiece-oriented <see cref="ISentenceEncoder.ChunkTokens"/> default.
         /// </summary>
         /// <param name="text">Source text to chunk.</param>
         /// <param name="chunkLength">Maximum tokens per chunk.</param>
@@ -168,19 +170,19 @@ namespace SentenceTransformers.Qwen3
         /// <param name="maxChunks">Hard cap on the number of chunks returned.</param>
         /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
         public List<string> ChunkTokens(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
-            => ((ISentenceEncoder)this).ChunkTokens(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+            => BPEChunkAndEncodeHelpers.ChunkTokens(Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress);
 
         /// <summary>
-        /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries offsets back into the
-        /// source text. Equivalent to <see cref="ISentenceEncoder.ChunkTokensAligned"/>.
+        /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries offsets back into
+        /// <paramref name="text"/>.
         /// </summary>
         /// <inheritdoc cref="ChunkTokens"/>
         public List<AlignedString> ChunkTokensAligned(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
-            => ((ISentenceEncoder)this).ChunkTokensAligned(text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+            => BPEChunkAndEncodeHelpers.ChunkTokensAligned(Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress);
 
         /// <summary>
-        /// Splits <paramref name="text"/> into token-bounded chunks and encodes each chunk to an embedding.
-        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAsync"/>.
+        /// Splits <paramref name="text"/> into BPE-token-bounded chunks and encodes each chunk to
+        /// an embedding. Uses offset-based chunk reconstruction (see <see cref="ChunkTokens"/>).
         /// </summary>
         /// <param name="text">Source text. May be longer than <see cref="MaxChunkLength"/>.</param>
         /// <param name="chunkLength">Maximum tokens per chunk. Values <c>&lt;= 0</c> or above <see cref="MaxChunkLength"/> are clamped to <see cref="MaxChunkLength"/>.</param>
@@ -191,38 +193,36 @@ namespace SentenceTransformers.Qwen3
         /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         public Task<EncodedChunk[]> ChunkAndEncodeAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeAsync(this, text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         /// <summary>
-        /// Aligned variant of <see cref="ChunkAndEncodeAsync"/>: results carry offsets back into
-        /// <paramref name="text"/>. Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeAlignedAsync"/>.
+        /// Aligned variant of <see cref="ChunkAndEncodeAsync"/>: each result also carries offsets
+        /// back into <paramref name="text"/>.
         /// </summary>
         /// <inheritdoc cref="ChunkAndEncodeAsync"/>
         public Task<EncodedChunkAligned[]> ChunkAndEncodeAlignedAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeAlignedAsync(text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeAlignedAsync(this, text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         /// <summary>
-        /// Chunks <paramref name="text"/> on token boundaries, then for each chunk invokes
-        /// <paramref name="stripTags"/> to remove injected markers and recover a tag (for example,
-        /// page numbers extracted from markers like <c>⁎12⁑</c>) before encoding the cleaned text.
-        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAsync"/>.
+        /// Chunks <paramref name="text"/> using BPE offsets, then for each chunk runs
+        /// <paramref name="stripTags"/> to remove injected markers and recover a tag before
+        /// encoding the cleaned text. The chunker treats markers as ordinary tokens.
         /// </summary>
         /// <param name="text">Source text with injected markers.</param>
         /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/> (cleaned text + tag).</param>
         /// <inheritdoc cref="ChunkAndEncodeAsync"/>
         public Task<TaggedEncodedChunk[]> ChunkAndEncodeTaggedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAsync(this, text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         /// <summary>
         /// Aligned variant of <see cref="ChunkAndEncodeTaggedAsync"/>: each result carries offsets
         /// into <paramref name="text"/> alongside the cleaned text, tag, and embedding.
-        /// Equivalent to <see cref="ISentenceEncoder.ChunkAndEncodeTaggedAlignedAsync"/>.
         /// </summary>
         /// <param name="text">Source text with injected markers.</param>
-        /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/>.</param>
+        /// <param name="stripTags">Callback that strips markers from the original chunk substring and produces a <see cref="TaggedChunk"/>.</param>
         /// <inheritdoc cref="ChunkAndEncodeAsync"/>
         public Task<TaggedEncodedChunkAligned[]> ChunkAndEncodeTaggedAlignedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
-            => ((ISentenceEncoder)this).ChunkAndEncodeTaggedAlignedAsync(text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAlignedAsync(this, text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
 
         private List<NamedOnnxValue> BuildModelInputs(
             List<(long[] InputIds, long[] TokenTypeIds, long[] AttentionMask)> encoded,

--- a/SentenceTransformers.Tests/BPEChunkAndEncodeTests.cs
+++ b/SentenceTransformers.Tests/BPEChunkAndEncodeTests.cs
@@ -1,0 +1,255 @@
+using SentenceTransformers.Qwen3;
+using SentenceTransformers.Tests.Support;
+
+namespace SentenceTransformers.Tests;
+
+/// <summary>
+/// End-to-end tests for the BPE chunk+encode pipeline, using a <see cref="FakeSentenceEncoder"/>
+/// so no model is loaded. These tests focus on:
+/// <list type="bullet">
+/// <item>What text actually reaches <c>EncodeAsync</c> after chunking.</item>
+/// <item>Marker injection / stripping: tags are recovered, markers are removed before encoding.</item>
+/// <item>Cancellation and <c>keepResultsOnCancellation</c>.</item>
+/// </list>
+/// </summary>
+public class BPEChunkAndEncodeTests
+{
+    private const int MaxTokens = 1024;
+
+    private static (FakeSentenceEncoder encoder, QwenTokenizer tokenizer) NewFakeWithQwen()
+    {
+        var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, MaxTokens);
+        return (new FakeSentenceEncoder(tok, MaxTokens), tok);
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeAsync_ReturnsOneVectorPerChunk()
+    {
+        var (encoder, tok) = NewFakeWithQwen();
+        try
+        {
+            var text = string.Join(' ', Enumerable.Range(0, 200).Select(i => $"word{i}"));
+            var result = await BPEChunkAndEncodeHelpers.ChunkAndEncodeAsync(encoder, text, chunkLength: 16, chunkOverlap: 2);
+            Assert.NotEmpty(result);
+            Assert.All(result, c =>
+            {
+                Assert.False(string.IsNullOrEmpty(c.Text));
+                Assert.NotEmpty(c.Vector);
+            });
+        }
+        finally
+        {
+            tok.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeAsync_Sequentially_SendsOneChunkPerCall()
+    {
+        var (encoder, tok) = NewFakeWithQwen();
+        try
+        {
+            var text = string.Join(' ', Enumerable.Range(0, 100).Select(i => $"w{i}"));
+            var result = await BPEChunkAndEncodeHelpers.ChunkAndEncodeAsync(encoder, text, chunkLength: 16, chunkOverlap: 2, sequentially: true);
+
+            Assert.Equal(result.Length, encoder.CallCount);
+            Assert.All(encoder.ReceivedBatches, b => Assert.Single(b));
+        }
+        finally
+        {
+            tok.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeAsync_Batched_SendsAllChunksInOneCall()
+    {
+        var (encoder, tok) = NewFakeWithQwen();
+        try
+        {
+            var text = string.Join(' ', Enumerable.Range(0, 100).Select(i => $"w{i}"));
+            var result = await BPEChunkAndEncodeHelpers.ChunkAndEncodeAsync(encoder, text, chunkLength: 16, chunkOverlap: 2, sequentially: false);
+
+            Assert.Equal(1, encoder.CallCount);
+            Assert.Equal(result.Length, encoder.ReceivedBatches[0].Length);
+        }
+        finally
+        {
+            tok.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeAlignedAsync_OffsetsMatchSource()
+    {
+        var (encoder, tok) = NewFakeWithQwen();
+        try
+        {
+            var text = "The quick brown fox jumps over the lazy dog. " +
+                       "Pack my box with five dozen liquor jugs. " +
+                       "Sphinx of black quartz, judge my vow.";
+
+            var result = await BPEChunkAndEncodeHelpers.ChunkAndEncodeAlignedAsync(encoder, text, chunkLength: 12, chunkOverlap: 2);
+            Assert.NotEmpty(result);
+            Assert.All(result, c =>
+            {
+                Assert.Equal(text, c.OriginalText);
+                Assert.True(c.Start >= 0);
+                Assert.True(c.ApproximateEnd <= text.Length);
+                Assert.Equal(text.Substring(c.Start, c.ApproximateEnd - c.Start), c.Text);
+            });
+        }
+        finally
+        {
+            tok.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeTaggedAsync_StripsInjectedMarkers_AndRecoversTags()
+    {
+        var (encoder, tok) = NewFakeWithQwen();
+        try
+        {
+            var text = "⁎1⁑page one body. more page one. ⁎2⁑page two body. yet more page two text content here.";
+
+            var result = await BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAsync(
+                encoder, text, PageMarker.StripPageTags, chunkLength: 16, chunkOverlap: 2);
+            Assert.NotEmpty(result);
+
+            // The encoder must not see any of the injected markers — they were stripped first.
+            foreach (var batch in encoder.ReceivedBatches)
+            {
+                foreach (var s in batch)
+                {
+                    Assert.DoesNotContain(PageMarker.Start, s);
+                    Assert.DoesNotContain(PageMarker.End, s);
+                }
+            }
+
+            // Every chunk's Text equals what was sent to EncodeAsync.
+            foreach (var c in result)
+            {
+                Assert.DoesNotContain(PageMarker.Start, c.Text);
+                Assert.DoesNotContain(PageMarker.End, c.Text);
+            }
+
+            // At least some chunks should carry a non-empty tag derived from the markers.
+            Assert.Contains(result, c => !string.IsNullOrEmpty(c.Tag));
+
+            // Tags should only ever be "1", "2", or "1-2" given our input.
+            Assert.All(result, c =>
+            {
+                Assert.Contains(c.Tag, new[] { string.Empty, "1", "2", "1-2" });
+            });
+        }
+        finally
+        {
+            tok.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeTaggedAlignedAsync_OffsetsMatchSource_AndMarkersStripped()
+    {
+        var (encoder, tok) = NewFakeWithQwen();
+        try
+        {
+            var text = "⁎1⁑First page sentence. Another first page sentence here. ⁎2⁑Second page sentence. Another second page sentence.";
+
+            var result = await BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAlignedAsync(
+                encoder, text, PageMarker.StripPageTags, chunkLength: 16, chunkOverlap: 2);
+
+            Assert.NotEmpty(result);
+            Assert.All(result, c =>
+            {
+                Assert.Equal(text, c.OriginalText);
+                Assert.True(c.Start >= 0 && c.ApproximateEnd <= text.Length);
+                Assert.DoesNotContain(PageMarker.Start, c.Text);
+                Assert.DoesNotContain(PageMarker.End, c.Text);
+            });
+
+            // The substring extracted from OriginalText should still contain markers (those are
+            // injected in the source); only the cleaned chunk Text drops them.
+            Assert.Contains(result, c => text.Substring(c.Start, c.ApproximateEnd - c.Start).Contains(PageMarker.Start));
+        }
+        finally
+        {
+            tok.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeTaggedAsync_NullStripTags_Throws()
+    {
+        var (encoder, tok) = NewFakeWithQwen();
+        try
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAsync(encoder, "hi", null));
+        }
+        finally
+        {
+            tok.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeAsync_Cancellation_WithKeepResults_ReturnsPartial()
+    {
+        // Encoder that throws OperationCanceledException after the first batch.
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, MaxTokens);
+        using var cts = new CancellationTokenSource();
+
+        var encoder = new CountingCancellingEncoder(tok, MaxTokens, cancelAfter: 2, cts);
+
+        var text = string.Join(' ', Enumerable.Range(0, 200).Select(i => $"w{i}"));
+
+        var result = await BPEChunkAndEncodeHelpers.ChunkAndEncodeAsync(
+            encoder, text, chunkLength: 16, chunkOverlap: 2,
+            sequentially: true, keepResultsOnCancellation: true,
+            cancellationToken: cts.Token);
+
+        // We expect at least one chunk to have been encoded before cancellation.
+        Assert.NotEmpty(result);
+        // ...but fewer than the full chunk count.
+        var allChunks = BPEChunkAndEncodeHelpers.ChunkTokens(tok, text, 16, 2);
+        Assert.True(result.Length < allChunks.Count,
+            $"Expected partial results (<{allChunks.Count}), got {result.Length}");
+    }
+
+    /// <summary>Encoder helper that cancels its <see cref="CancellationTokenSource"/> after a fixed number of calls.</summary>
+    private sealed class CountingCancellingEncoder : ISentenceEncoder
+    {
+        private readonly CancellationTokenSource _cts;
+        private readonly int _cancelAfter;
+        private int _calls;
+
+        public CountingCancellingEncoder(BERTTokenizers.Base.TokenizerBase tokenizer, int maxChunkLength, int cancelAfter, CancellationTokenSource cts)
+        {
+            Tokenizer = tokenizer;
+            MaxChunkLength = maxChunkLength;
+            _cancelAfter = cancelAfter;
+            _cts = cts;
+        }
+
+        public int MaxChunkLength { get; }
+        public BERTTokenizers.Base.TokenizerBase Tokenizer { get; }
+
+        public Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _calls++;
+            if (_calls > _cancelAfter)
+            {
+                _cts.Cancel();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            var v = new float[sentences.Length][];
+            for (int i = 0; i < sentences.Length; i++) v[i] = new float[1] { sentences[i].Length };
+            return Task.FromResult(v);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/SentenceTransformers.Tests/BPEChunkingHelpersTests.cs
+++ b/SentenceTransformers.Tests/BPEChunkingHelpersTests.cs
@@ -1,0 +1,153 @@
+using SentenceTransformers.Harrier;
+using SentenceTransformers.Qwen3;
+using SentenceTransformers.Tests.Support;
+
+namespace SentenceTransformers.Tests;
+
+/// <summary>
+/// Tests for <see cref="BPEChunkAndEncodeHelpers"/>: the offset-based chunker used by Qwen3 and
+/// Harrier. The chunk text must always equal the source substring between the first and last
+/// token's offsets — preserving whitespace, punctuation, and any injected markers verbatim.
+/// </summary>
+public class BPEChunkingHelpersTests
+{
+    private const int MaxTokens = 1024;
+
+    private static QwenTokenizer NewQwen() => new(TestPaths.QwenTokenizerJson, MaxTokens);
+    private static HarrierTokenizer NewHarrier() => new(TestPaths.HarrierTokenizerJson, MaxTokens);
+
+    [Fact]
+    public void ChunkTokens_EmptyText_ReturnsEmpty()
+    {
+        using var tok = NewQwen();
+        var chunks = BPEChunkAndEncodeHelpers.ChunkTokens(tok, string.Empty);
+        Assert.Empty(chunks);
+    }
+
+    [Fact]
+    public void ChunkTokens_ShortText_FitsInOneChunk()
+    {
+        using var tok = NewQwen();
+        var text = "hello world";
+        var chunks = BPEChunkAndEncodeHelpers.ChunkTokens(tok, text, chunkLength: 32, chunkOverlap: 4);
+        Assert.Single(chunks);
+        Assert.Equal(text, chunks[0]);
+    }
+
+    [Fact]
+    public void ChunkTokens_LongText_ProducesMultipleChunksWithExpectedOverlap()
+    {
+        using var tok = NewQwen();
+        var text = string.Join(' ', Enumerable.Range(0, 200).Select(i => $"word{i}"));
+
+        var chunks = BPEChunkAndEncodeHelpers.ChunkTokens(tok, text, chunkLength: 16, chunkOverlap: 4);
+        Assert.True(chunks.Count > 1, "Expected multiple chunks for long input");
+
+        // Each chunk must be a substring of the source.
+        foreach (var c in chunks)
+        {
+            Assert.Contains(c, text);
+        }
+
+        // Consecutive chunks should share content (overlap > 0).
+        var aligned = BPEChunkAndEncodeHelpers.ChunkTokensAligned(tok, text, chunkLength: 16, chunkOverlap: 4);
+        Assert.Equal(chunks.Count, aligned.Count);
+        for (int i = 1; i < aligned.Count; i++)
+        {
+            Assert.True(aligned[i].Start < aligned[i - 1].ApproximateEnd,
+                $"Chunk {i} (start {aligned[i].Start}) should start before chunk {i - 1} ends ({aligned[i - 1].ApproximateEnd}) when overlap > 0");
+        }
+    }
+
+    [Fact]
+    public void ChunkTokensAligned_ChunkValueEqualsSourceSubstring()
+    {
+        using var tok = NewQwen();
+        var text = "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs.";
+
+        var aligned = BPEChunkAndEncodeHelpers.ChunkTokensAligned(tok, text, chunkLength: 8, chunkOverlap: 2);
+        Assert.NotEmpty(aligned);
+
+        foreach (var c in aligned)
+        {
+            var expected = text.Substring(c.Start, c.ApproximateEnd - c.Start);
+            Assert.Equal(expected, c.Value);
+        }
+    }
+
+    [Fact]
+    public void ChunkTokensAligned_PreservesInjectedMarkers_Verbatim()
+    {
+        // Inject page markers between sentences; the chunker must keep them verbatim in the chunk
+        // text so a downstream stripTags callback can recover the page numbers.
+        using var tok = NewQwen();
+        var text = "⁎1⁑first sentence one. first sentence two. ⁎2⁑second sentence one. second sentence two.";
+
+        var aligned = BPEChunkAndEncodeHelpers.ChunkTokensAligned(tok, text, chunkLength: 12, chunkOverlap: 2);
+        Assert.NotEmpty(aligned);
+
+        var allChunks = string.Concat(aligned.Select(c => c.Value));
+        Assert.Contains("⁎1⁑", allChunks);
+        Assert.Contains("⁎2⁑", allChunks);
+
+        foreach (var c in aligned)
+        {
+            Assert.Equal(text.Substring(c.Start, c.ApproximateEnd - c.Start), c.Value);
+        }
+    }
+
+    [Fact]
+    public void ChunkTokens_MaxChunksCap_IsHonored()
+    {
+        using var tok = NewQwen();
+        var text = string.Join(' ', Enumerable.Range(0, 500).Select(i => $"w{i}"));
+
+        var chunks = BPEChunkAndEncodeHelpers.ChunkTokens(tok, text, chunkLength: 16, chunkOverlap: 2, maxChunks: 3);
+        Assert.True(chunks.Count <= 3, $"Expected <=3 chunks, got {chunks.Count}");
+    }
+
+    [Fact]
+    public void ChunkTokens_ClampsChunkLengthToMaxTokens()
+    {
+        var maxTokens = 32;
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, maxTokens);
+        var text = string.Join(' ', Enumerable.Range(0, 200).Select(i => $"word{i}"));
+
+        // Pass an out-of-range chunkLength; the helper should clamp to maxTokens (32) instead.
+        var chunks = BPEChunkAndEncodeHelpers.ChunkTokens(tok, text, chunkLength: 1_000_000, chunkOverlap: 100);
+        Assert.NotEmpty(chunks);
+    }
+
+    [Fact]
+    public void ChunkTokens_DefaultsOverlap_WhenOutOfRange()
+    {
+        using var tok = NewQwen();
+        var text = string.Join(' ', Enumerable.Range(0, 100).Select(i => $"w{i}"));
+
+        // Passing chunkOverlap >= chunkLength should default to chunkLength / 5. We don't assert
+        // the exact value but we do require the call to succeed and produce at least one chunk.
+        var chunks = BPEChunkAndEncodeHelpers.ChunkTokens(tok, text, chunkLength: 16, chunkOverlap: 16);
+        Assert.NotEmpty(chunks);
+    }
+
+    [Fact]
+    public void ChunkTokensAligned_Harrier_PreservesUnicodeContent()
+    {
+        using var tok = NewHarrier();
+        // Mix of scripts to exercise multi-byte handling.
+        var text = "English text. Texte français. 中文文本。 العربية. русский.";
+        var aligned = BPEChunkAndEncodeHelpers.ChunkTokensAligned(tok, text, chunkLength: 8, chunkOverlap: 2);
+        Assert.NotEmpty(aligned);
+
+        foreach (var c in aligned)
+        {
+            Assert.Equal(text.Substring(c.Start, c.ApproximateEnd - c.Start), c.Value);
+        }
+    }
+
+    [Fact]
+    public void ChunkTokens_NullTokenizer_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => BPEChunkAndEncodeHelpers.ChunkTokens(null, "text"));
+    }
+}

--- a/SentenceTransformers.Tests/BPETokenizerTests.cs
+++ b/SentenceTransformers.Tests/BPETokenizerTests.cs
@@ -1,0 +1,156 @@
+using SentenceTransformers.Harrier;
+using SentenceTransformers.Qwen3;
+using SentenceTransformers.Tests.Support;
+
+namespace SentenceTransformers.Tests;
+
+/// <summary>
+/// Tests for the Hugging Face byte-level BPE tokenizers used by Qwen3 and Harrier. The tests
+/// construct the tokenizers directly from the shipped <c>tokenizer.json</c> files (no ONNX model
+/// is loaded).
+/// </summary>
+public class BPETokenizerTests
+{
+    private const int MaxTokens = 1024;
+
+    [Fact]
+    public void QwenTokenizer_TokenizeRaw_OriginalsConcatenateToSource()
+    {
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, MaxTokens);
+        var text = "Hello world, this is a test.";
+        var raw = tok.TokenizeRaw(text);
+        Assert.NotEmpty(raw);
+
+        // Byte-level BPE offsets are expected to be contiguous; concatenating the originals
+        // should reconstruct the source exactly. (This is what BPEChunkAndEncodeHelpers relies on
+        // indirectly via offsets — verifying it here catches tokenizer-config drift.)
+        var concat = string.Concat(raw.Select(t => t.Original ?? string.Empty));
+        Assert.Equal(text, concat);
+    }
+
+    [Fact]
+    public void QwenTokenizer_TokenizeRawAligned_OffsetsAreContiguousAndMonotonic()
+    {
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, MaxTokens);
+        var text = "The quick brown fox jumps over the lazy dog.";
+        var aligned = tok.TokenizeRawAligned(text);
+        Assert.NotEmpty(aligned);
+
+        Assert.Equal(0, aligned[0].Start);
+        Assert.Equal(text.Length, aligned[^1].ApproximateEnd);
+
+        for (int i = 1; i < aligned.Count; i++)
+        {
+            Assert.True(aligned[i].Start >= aligned[i - 1].Start,
+                $"Token {i} starts at {aligned[i].Start} but previous at {aligned[i - 1].Start}");
+        }
+
+        // Every aligned token's Original must be the exact substring of source at its offsets.
+        foreach (var t in aligned)
+        {
+            var expected = text.Substring(t.Start, t.ApproximateEnd - t.Start);
+            Assert.Equal(expected, t.Original);
+        }
+    }
+
+    [Fact]
+    public void QwenTokenizer_Encode_AddsSpecialTokens_AndProducesAlignedArrays()
+    {
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, MaxTokens);
+        var encoded = tok.Encode(["hello", "hi there world"]);
+        Assert.Equal(2, encoded.Count);
+        Assert.All(encoded, row =>
+        {
+            Assert.NotEmpty(row.InputIds);
+            Assert.Equal(row.InputIds.Length, row.AttentionMask.Length);
+            Assert.Equal(row.InputIds.Length, row.TokenTypeIds.Length);
+        });
+    }
+
+    [Fact]
+    public void QwenTokenizer_Encode_TruncatesToMaxTokens()
+    {
+        var maxTokens = 8;
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, maxTokens);
+        var encoded = tok.Encode(["one two three four five six seven eight nine ten eleven twelve thirteen"]);
+        Assert.Single(encoded);
+        Assert.True(encoded[0].InputIds.Length <= maxTokens,
+            $"InputIds length {encoded[0].InputIds.Length} exceeds maxTokens {maxTokens}");
+    }
+
+    [Fact]
+    public void QwenTokenizer_TokenizeRaw_OnEmptyText_ReturnsEmptyList()
+    {
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, MaxTokens);
+        var raw = tok.TokenizeRaw(string.Empty);
+        Assert.Empty(raw);
+    }
+
+    [Fact]
+    public void QwenTokenizer_TokenizeRawAligned_OffsetsCoverEveryCharacter_EvenForUnicodeMarkers()
+    {
+        // For some Unicode inputs the HF BPE tokenizer emits tokens with overlapping offsets, so
+        // concatenating Original substrings naively may not reproduce the source. The offset-based
+        // BPE chunker handles this correctly because it slices the source between the first and
+        // last token's offsets rather than relying on per-token text round-trips. This test asserts
+        // the property the chunker actually depends on: the union of every token's
+        // [Start, ApproximateEnd) range covers every character of the input, and the first/last
+        // token bracket the source exactly.
+        using var tok = new QwenTokenizer(TestPaths.QwenTokenizerJson, MaxTokens);
+        var text = "⁎1⁑ first page text ⁎2⁑ second page text";
+        var aligned = tok.TokenizeRawAligned(text);
+
+        Assert.NotEmpty(aligned);
+        Assert.Equal(0, aligned[0].Start);
+        Assert.Equal(text.Length, aligned[^1].ApproximateEnd);
+
+        var covered = new bool[text.Length];
+        foreach (var t in aligned)
+        {
+            for (int i = t.Start; i < t.ApproximateEnd && i < text.Length; i++) covered[i] = true;
+        }
+        for (int i = 0; i < covered.Length; i++)
+        {
+            Assert.True(covered[i], $"Character at offset {i} ('{text[i]}') is not covered by any token");
+        }
+    }
+
+    [Fact]
+    public void HarrierTokenizer_TokenizeRaw_OriginalsConcatenateToSource()
+    {
+        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        var text = "Multilingual embeddings test 123.";
+        var raw = tok.TokenizeRaw(text);
+        var concat = string.Concat(raw.Select(t => t.Original ?? string.Empty));
+        Assert.Equal(text, concat);
+    }
+
+    [Fact]
+    public void HarrierTokenizer_TokenizeRawAligned_OffsetsCoverSource()
+    {
+        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        var text = "Bonjour le monde, ceci est un test.";
+        var aligned = tok.TokenizeRawAligned(text);
+        Assert.NotEmpty(aligned);
+        Assert.Equal(0, aligned[0].Start);
+        Assert.Equal(text.Length, aligned[^1].ApproximateEnd);
+    }
+
+    [Fact]
+    public void HarrierTokenizer_Encode_ProducesAlignedArrays()
+    {
+        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        var encoded = tok.Encode(["hello world"]);
+        Assert.Single(encoded);
+        Assert.Equal(encoded[0].InputIds.Length, encoded[0].AttentionMask.Length);
+        Assert.Equal(encoded[0].InputIds.Length, encoded[0].TokenTypeIds.Length);
+    }
+
+    [Fact]
+    public void HarrierTokenizer_TokenizeSimple_NotEmpty()
+    {
+        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        var tokens = tok.TokenizeSimple("Embeddings for multilingual text");
+        Assert.NotEmpty(tokens);
+    }
+}

--- a/SentenceTransformers.Tests/ChunkStringTests.cs
+++ b/SentenceTransformers.Tests/ChunkStringTests.cs
@@ -1,0 +1,43 @@
+namespace SentenceTransformers.Tests;
+
+/// <summary>
+/// Tests for the tokenizer-free <see cref="ISentenceEncoder.ChunkString"/> static helper.
+/// </summary>
+public class ChunkStringTests
+{
+    [Fact]
+    public void ChunkString_ShortText_ReturnsSingleChunk()
+    {
+        var chunks = ISentenceEncoder.ChunkString("hello world", chunkLength: 100, chunkOverlap: 10);
+        Assert.Single(chunks);
+        Assert.Equal("hello world", chunks[0]);
+    }
+
+    [Fact]
+    public void ChunkString_LongText_SplitsOnWhitespace_AndRespectsChunkLength()
+    {
+        var words = Enumerable.Range(0, 50).Select(i => $"w{i}").ToArray();
+        var text = string.Join(' ', words);
+
+        var chunks = ISentenceEncoder.ChunkString(text, chunkLength: 30, chunkOverlap: 8);
+        Assert.True(chunks.Count > 1, $"Expected multiple chunks, got {chunks.Count}");
+        Assert.All(chunks, c => Assert.True(c.Length <= 30, $"Chunk length {c.Length} exceeded chunkLength=30: {c}"));
+    }
+
+    [Fact]
+    public void ChunkString_MaxChunksCap_IsHonored()
+    {
+        var words = Enumerable.Range(0, 200).Select(i => $"w{i}").ToArray();
+        var text = string.Join(' ', words);
+
+        var chunks = ISentenceEncoder.ChunkString(text, chunkLength: 30, chunkOverlap: 5, maxChunks: 3);
+        Assert.True(chunks.Count <= 4, $"Expected ~3 chunks, got {chunks.Count}");
+    }
+
+    [Fact]
+    public void ChunkString_EmptyInput_ReturnsEmpty()
+    {
+        var chunks = ISentenceEncoder.ChunkString(string.Empty);
+        Assert.Empty(chunks);
+    }
+}

--- a/SentenceTransformers.Tests/SentenceTransformers.Tests.csproj
+++ b/SentenceTransformers.Tests/SentenceTransformers.Tests.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SentenceTransformers\SentenceTransformers.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.MiniLM\SentenceTransformers.MiniLM.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.ArcticXs\SentenceTransformers.ArcticXs.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Qwen3\SentenceTransformers.Qwen3.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier\SentenceTransformers.Harrier.csproj" />
+  </ItemGroup>
+
+  <!--
+    Qwen and Harrier both ship Resources\tokenizer.json. Referencing both projects copies them to
+    the same output path; we instead link the source tokenizer.json files under distinct filenames
+    so tests can load each by path.
+  -->
+  <ItemGroup>
+    <None Include="..\SentenceTransformers.Qwen3\Resources\tokenizer.json" Link="Resources\qwen-tokenizer.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\SentenceTransformers.Harrier\Resources\tokenizer.json" Link="Resources\harrier-tokenizer.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/SentenceTransformers.Tests/Support/FakeSentenceEncoder.cs
+++ b/SentenceTransformers.Tests/Support/FakeSentenceEncoder.cs
@@ -1,0 +1,51 @@
+using BERTTokenizers.Base;
+using SentenceTransformers;
+
+namespace SentenceTransformers.Tests.Support;
+
+/// <summary>
+/// In-memory <see cref="ISentenceEncoder"/> that captures every batch passed to
+/// <see cref="EncodeAsync"/> and returns deterministic dummy vectors. Lets us exercise the
+/// chunk+encode pipeline (including marker injection / stripping flows) without loading an ONNX
+/// model or downloading anything.
+/// </summary>
+internal sealed class FakeSentenceEncoder : ISentenceEncoder
+{
+    private readonly int _dim;
+
+    public FakeSentenceEncoder(TokenizerBase tokenizer, int maxChunkLength, int dim = 4)
+    {
+        Tokenizer = tokenizer;
+        MaxChunkLength = maxChunkLength;
+        _dim = dim;
+    }
+
+    public int MaxChunkLength { get; }
+
+    public TokenizerBase Tokenizer { get; }
+
+    public List<string[]> ReceivedBatches { get; } = new();
+
+    public int CallCount => ReceivedBatches.Count;
+
+    public Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ReceivedBatches.Add(sentences.ToArray());
+
+        var vectors = new float[sentences.Length][];
+        for (int i = 0; i < sentences.Length; i++)
+        {
+            var v = new float[_dim];
+            var s = sentences[i] ?? string.Empty;
+            v[0] = s.Length;
+            v[1] = s.Length == 0 ? 0 : s[0];
+            v[2] = s.GetHashCode();
+            v[3] = i;
+            vectors[i] = v;
+        }
+        return Task.FromResult(vectors);
+    }
+
+    public void Dispose() { }
+}

--- a/SentenceTransformers.Tests/Support/PageMarker.cs
+++ b/SentenceTransformers.Tests/Support/PageMarker.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+using SentenceTransformers;
+
+namespace SentenceTransformers.Tests.Support;
+
+/// <summary>
+/// Re-implementation of the page-marker workflow from <c>SentenceTransformers.TestBase</c>:
+/// callers inject <c>⁎N⁑</c> markers into the source text; this helper strips them and recovers
+/// the page range as a tag (for example <c>"1"</c> or <c>"1-2"</c>).
+/// </summary>
+internal static class PageMarker
+{
+    public const char Start = '⁎';
+    public const char End = '⁑';
+    private static readonly Regex Pattern = new($"{Start}\\d+{End}", RegexOptions.Compiled);
+
+    public static TaggedChunk StripPageTags(string chunk)
+    {
+        var pages = new List<int>();
+        var cleaned = Pattern.Replace(chunk, match =>
+        {
+            var page = match.ValueSpan.Slice(1, match.ValueSpan.Length - 2);
+            if (int.TryParse(page, out var p)) pages.Add(p);
+            return string.Empty;
+        });
+
+        if (pages.Count == 0) return new TaggedChunk(cleaned, string.Empty);
+        var lo = pages.Min();
+        var hi = pages.Max();
+        return new TaggedChunk(cleaned, lo == hi ? lo.ToString() : $"{lo}-{hi}");
+    }
+}

--- a/SentenceTransformers.Tests/Support/TestPaths.cs
+++ b/SentenceTransformers.Tests/Support/TestPaths.cs
@@ -1,0 +1,7 @@
+namespace SentenceTransformers.Tests.Support;
+
+internal static class TestPaths
+{
+    public static string QwenTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "qwen-tokenizer.json");
+    public static string HarrierTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "harrier-tokenizer.json");
+}

--- a/SentenceTransformers.Tests/WordPieceChunkingTests.cs
+++ b/SentenceTransformers.Tests/WordPieceChunkingTests.cs
@@ -1,0 +1,122 @@
+using SentenceTransformers.MiniLM;
+using SentenceTransformers.Tests.Support;
+
+namespace SentenceTransformers.Tests;
+
+/// <summary>
+/// Tests for the WordPiece-oriented chunking defaults that <see cref="ISentenceEncoder"/> provides
+/// (used by MiniLM and Arctic). The MiniLM encoder is used as a vehicle for the interface default
+/// methods. The ONNX model is loaded from the embedded resources of the MiniLM assembly; no
+/// network access is needed.
+/// </summary>
+public class WordPieceChunkingTests
+{
+    [Fact]
+    public void ChunkTokens_LongText_ProducesMultipleChunks()
+    {
+        using var enc = new SentenceEncoder();
+        ISentenceEncoder iface = enc;
+
+        var text = string.Join(' ', Enumerable.Range(0, 400).Select(i => $"word{i}"));
+        var chunks = iface.ChunkTokens(text, chunkLength: 32, chunkOverlap: 4);
+        Assert.True(chunks.Count > 1, "Expected multiple chunks");
+        Assert.All(chunks, c => Assert.False(string.IsNullOrWhiteSpace(c)));
+    }
+
+    [Fact]
+    public void ChunkTokensAligned_ChunksHaveValidOffsets()
+    {
+        using var enc = new SentenceEncoder();
+        ISentenceEncoder iface = enc;
+
+        var text = "The quick brown fox jumps over the lazy dog. " +
+                   "Pack my box with five dozen liquor jugs. " +
+                   "Sphinx of black quartz, judge my vow.";
+
+        var chunks = iface.ChunkTokensAligned(text, chunkLength: 16, chunkOverlap: 2);
+        Assert.NotEmpty(chunks);
+        Assert.All(chunks, c =>
+        {
+            Assert.True(c.Start >= 0);
+            Assert.True(c.ApproximateEnd <= text.Length);
+            Assert.True(c.ApproximateEnd >= c.Start);
+            Assert.Equal(text, c.OriginalText);
+        });
+    }
+
+    [Fact]
+    public void ChunkTokens_MaxChunksCap_IsRespected()
+    {
+        using var enc = new SentenceEncoder();
+        ISentenceEncoder iface = enc;
+
+        var text = string.Join(' ', Enumerable.Range(0, 500).Select(i => $"w{i}"));
+        var chunks = iface.ChunkTokens(text, chunkLength: 16, chunkOverlap: 2, maxChunks: 3);
+        Assert.True(chunks.Count <= 4, $"Expected ~3 chunks, got {chunks.Count}");
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeAsync_ReturnsOneVectorPerChunk_AndVectorsAreNormalized()
+    {
+        using var enc = new SentenceEncoder();
+        ISentenceEncoder iface = enc;
+
+        var text = string.Join(' ', Enumerable.Range(0, 200).Select(i => $"word{i}"));
+        var result = await iface.ChunkAndEncodeAsync(text, chunkLength: 32, chunkOverlap: 4);
+
+        Assert.NotEmpty(result);
+        Assert.All(result, c =>
+        {
+            Assert.False(string.IsNullOrEmpty(c.Text));
+            Assert.Equal(384, c.Vector.Length);
+            var norm = MathF.Sqrt(c.Vector.Sum(v => v * v));
+            Assert.InRange(norm, 0.99f, 1.01f);
+        });
+    }
+
+    [Fact]
+    public async Task ChunkAndEncodeTaggedAsync_RunsStripTagsCallback_AndEncodesCleanedText()
+    {
+        // The WordPiece pipeline runs the input through Unidecode + lowercase + delimiter
+        // splitting before chunk text is reassembled. Unicode markers (like the page tags used by
+        // the BPE tests) do not survive that pipeline, so this test verifies the contract — chunk
+        // text is fed through the stripTags callback and the callback's outputs reach EncodeAsync
+        // — without relying on a specific marker style.
+        using var enc = new SentenceEncoder();
+        ISentenceEncoder iface = enc;
+
+        var text = string.Join(' ', Enumerable.Range(0, 60).Select(i => $"sentence{i} alpha beta gamma delta."));
+
+        const string TagValue = "TAG-X";
+        const string CleanPrefix = "CLEAN: ";
+        TaggedChunk Strip(string chunk) => new TaggedChunk(CleanPrefix + chunk, TagValue);
+
+        var result = await iface.ChunkAndEncodeTaggedAsync(text, Strip, chunkLength: 24, chunkOverlap: 4);
+        Assert.NotEmpty(result);
+
+        Assert.All(result, c =>
+        {
+            Assert.StartsWith(CleanPrefix, c.Text);
+            Assert.Equal(TagValue, c.Tag);
+            Assert.Equal(384, c.Vector.Length);
+        });
+    }
+
+    [Fact]
+    public async Task EncodeAsync_BatchOfTwo_ProducesAlignedVectorPair()
+    {
+        using var enc = new SentenceEncoder();
+        var vectors = await enc.EncodeAsync(["hello world", "different sentence"]);
+        Assert.Equal(2, vectors.Length);
+        Assert.Equal(384, vectors[0].Length);
+        Assert.Equal(384, vectors[1].Length);
+
+        // The two vectors should differ — same vectors for distinct inputs would mean broken encoding.
+        var different = false;
+        for (int i = 0; i < vectors[0].Length; i++)
+        {
+            if (Math.Abs(vectors[0][i] - vectors[1][i]) > 1e-3f) { different = true; break; }
+        }
+        Assert.True(different, "Different sentences should produce different vectors");
+    }
+}

--- a/SentenceTransformers.Tests/WordPieceTokenizerTests.cs
+++ b/SentenceTransformers.Tests/WordPieceTokenizerTests.cs
@@ -1,0 +1,110 @@
+using BERTTokenizers.Base;
+using SentenceTransformers.ArcticXs;
+using SentenceTransformers.MiniLM;
+
+namespace SentenceTransformers.Tests;
+
+/// <summary>
+/// Tests for the WordPiece-based tokenizers (MiniLM and Arctic). They share an implementation
+/// via <see cref="TokenizerBase"/>, so most behaviors are exercised through the MiniLM tokenizer
+/// with a couple of Arctic-specific smoke tests.
+/// </summary>
+public class WordPieceTokenizerTests
+{
+    [Fact]
+    public void MiniLMTokenizer_TokenizeSimple_ReturnsSubwordTokens()
+    {
+        var tok = new MiniLMTokenizer();
+        var tokens = tok.TokenizeSimple("Hello world");
+        Assert.NotEmpty(tokens);
+        Assert.Contains("hello", tokens);
+        Assert.Contains("world", tokens);
+    }
+
+    [Fact]
+    public void MiniLMTokenizer_Encode_AddsCLSAndSEP_AndPadsBatch()
+    {
+        var tok = new MiniLMTokenizer();
+        tok.SetMaxTokens(32);
+        var encoded = tok.Encode("hello", "hi there world");
+        Assert.Equal(2, encoded.Count);
+
+        // All rows are padded to the longest row in the batch.
+        var len = encoded[0].InputIds.Length;
+        Assert.True(len > 2, "Encoded length should include CLS + content + SEP");
+        Assert.All(encoded, row =>
+        {
+            Assert.Equal(len, row.InputIds.Length);
+            Assert.Equal(len, row.AttentionMask.Length);
+            Assert.Equal(len, row.TokenTypeIds.Length);
+        });
+
+        // The CLS id appears as the first token in every row (it's the special [CLS]).
+        var clsId = encoded[0].InputIds[0];
+        Assert.All(encoded, row => Assert.Equal(clsId, row.InputIds[0]));
+    }
+
+    [Fact]
+    public void MiniLMTokenizer_TokenizeRaw_RoundTrips_ViaUntokenize()
+    {
+        var tok = new MiniLMTokenizer();
+        var input = "hello world this is a test";
+        var raw = tok.TokenizeRaw(input);
+        Assert.NotEmpty(raw);
+
+        var words = tok.Untokenize(raw);
+        var joined = string.Join(' ', words);
+        Assert.Equal("hello world this is a test", joined);
+    }
+
+    [Fact]
+    public void MiniLMTokenizer_TokenizeRawAligned_OffsetsCoverInput()
+    {
+        var tok = new MiniLMTokenizer();
+        var input = "hello world this is a test";
+        var aligned = tok.TokenizeRawAligned(input);
+        Assert.NotEmpty(aligned);
+
+        // The first token should start at 0; the last token should end at or before the input length.
+        Assert.Equal(0, aligned[0].Start);
+        Assert.True(aligned[^1].ApproximateEnd <= input.Length);
+
+        // Offsets should be non-decreasing.
+        for (int i = 1; i < aligned.Count; i++)
+        {
+            Assert.True(aligned[i].Start >= aligned[i - 1].Start,
+                $"Token {i} starts at {aligned[i].Start} but previous starts at {aligned[i - 1].Start}");
+        }
+    }
+
+    [Fact]
+    public void MiniLMTokenizer_TokenizeSentence_StripsRepeatedSpecialChars()
+    {
+        // The WordPiece tokenizer collapses runs of repeated special chars (per
+        // TokenizerBase.RemoveRepeatedSpecialChars). Verify that "????????" becomes one "?" so the
+        // chunker doesn't waste tokens on noise.
+        var tok = new MiniLMTokenizer();
+        var raw = tok.TokenizeRaw("hello????????world");
+        var untoken = string.Join(' ', tok.Untokenize(raw));
+        Assert.DoesNotContain("????", untoken);
+    }
+
+    [Fact]
+    public void ArcticTokenizer_TokenizeSimple_ReturnsSubwordTokens()
+    {
+        var tok = new ArcticTokenizer();
+        var tokens = tok.TokenizeSimple("Embedding tests");
+        Assert.NotEmpty(tokens);
+    }
+
+    [Fact]
+    public void ArcticTokenizer_Encode_ProducesAlignedBatch()
+    {
+        var tok = new ArcticTokenizer();
+        tok.SetMaxTokens(64);
+        var encoded = tok.Encode("the quick brown fox");
+        Assert.Single(encoded);
+        Assert.NotEmpty(encoded[0].InputIds);
+        Assert.Equal(encoded[0].InputIds.Length, encoded[0].AttentionMask.Length);
+    }
+}

--- a/SentenceTransformers.sln
+++ b/SentenceTransformers.sln
@@ -28,6 +28,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing", "Testing", "{9ACE
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Harrier", "SentenceTransformers.Harrier\SentenceTransformers.Harrier.csproj", "{AD66CF6D-160C-4B5E-9BAF-D7A2CDB6FC49}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Tests", "SentenceTransformers.Tests\SentenceTransformers.Tests.csproj", "{11CAD661-6EE5-41FA-812E-AECBE3F813F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -146,6 +148,18 @@ Global
 		{AD66CF6D-160C-4B5E-9BAF-D7A2CDB6FC49}.Release|x64.Build.0 = Release|Any CPU
 		{AD66CF6D-160C-4B5E-9BAF-D7A2CDB6FC49}.Release|x86.ActiveCfg = Release|Any CPU
 		{AD66CF6D-160C-4B5E-9BAF-D7A2CDB6FC49}.Release|x86.Build.0 = Release|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Debug|x64.Build.0 = Debug|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Debug|x86.Build.0 = Debug|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|x64.ActiveCfg = Release|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|x64.Build.0 = Release|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|x86.ActiveCfg = Release|Any CPU
+		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SentenceTransformers/src/BERTTokenizers/Base/TokenizerBase.cs
+++ b/SentenceTransformers/src/BERTTokenizers/Base/TokenizerBase.cs
@@ -217,7 +217,14 @@ namespace BERTTokenizers.Base
         {
             var alignedRemoved    = RemoveRepeatedSpecialCharsWithAlignment(text);
             var unidecoderRemoved = Unidecoder.FastUnidecodeWithAlignment(alignedRemoved.text, alignedRemoved.alignment);
-            AlignmentListPool.Return(alignedRemoved.alignment);
+
+            // For pure-ASCII input FastUnidecodeWithAlignment returns the same alignment list it
+            // was given; returning it to the pool here would clear it before TokenizeSentenceAligned
+            // reads it. Only release the original when Unidecode produced a fresh list.
+            if (!ReferenceEquals(alignedRemoved.alignment, unidecoderRemoved.alignment))
+            {
+                AlignmentListPool.Return(alignedRemoved.alignment);
+            }
 
             var result = TokenizeSentenceAligned(unidecoderRemoved.text, unidecoderRemoved.alignment)
                .SelectMany(TokenizeSubwordsAligned)

--- a/SentenceTransformers/src/BPEChunkAndEncodeHelpers.cs
+++ b/SentenceTransformers/src/BPEChunkAndEncodeHelpers.cs
@@ -1,0 +1,324 @@
+using BERTTokenizers.Base;
+using Mosaik.Core;
+
+namespace SentenceTransformers;
+
+/// <summary>
+/// Tokenizer-aware chunking and encoding helpers specialized for byte-level BPE tokenizers
+/// (Qwen, Harrier, and similar Hugging Face <c>tokenizer.json</c>-driven encoders).
+///
+/// Each chunk is reconstructed by slicing the source text between the first and last token's
+/// character offsets returned by <see cref="TokenizerBase.TokenizeRawAligned"/>. This is more
+/// robust than the WordPiece-oriented <c>Untokenize</c> + <c>string.Join(' ', …)</c> path used by
+/// the default <see cref="ISentenceEncoder"/> helpers, because:
+/// <list type="bullet">
+/// <item>It does not depend on subword markers (<c>##</c>) that BPE tokenizers do not emit.</item>
+/// <item>It preserves the exact original whitespace and punctuation, including any injected
+/// markers (for example <c>⁎12⁑</c>) added by the caller.</item>
+/// <item>It does not rely on token-by-token concatenation being contiguous, which can drop content
+/// if a tokenizer's pre-tokenizer ever yields non-adjacent offsets.</item>
+/// </list>
+/// The marker-injection / marker-stripping flow works the same way as the WordPiece helpers: the
+/// caller injects markers into the text, the chunker emits chunk substrings that still contain
+/// those markers, and a user-supplied <c>stripTags</c> callback removes them and produces a tag
+/// before each chunk is encoded.
+/// </summary>
+public static class BPEChunkAndEncodeHelpers
+{
+    /// <summary>Tokenizes <paramref name="text"/> using <paramref name="tokenizer"/> and emits chunks of at most
+    /// <paramref name="chunkLength"/> tokens with <paramref name="chunkOverlap"/> tokens of overlap. Each
+    /// chunk's text is sliced directly from <paramref name="text"/> between the first and last token's offsets.</summary>
+    /// <param name="tokenizer">Tokenizer providing offset-aligned tokenization.</param>
+    /// <param name="text">Source text to chunk. May be longer than the tokenizer's context window.</param>
+    /// <param name="chunkLength">Maximum tokens per chunk. Values <c>&lt;= 0</c> or above <see cref="TokenizerBase.MaxTokens"/> are clamped to <see cref="TokenizerBase.MaxTokens"/>.</param>
+    /// <param name="chunkOverlap">Tokens of overlap kept between consecutive chunks. Out-of-range values default to <c>chunkLength / 5</c>.</param>
+    /// <param name="maxChunks">Hard cap on chunks produced.</param>
+    /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+    public static List<string> ChunkTokens(TokenizerBase tokenizer, string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+    {
+        var aligned = ChunkTokensAligned(tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+        var result = new List<string>(aligned.Count);
+        for (int i = 0; i < aligned.Count; i++)
+        {
+            result.Add(aligned[i].Value);
+        }
+        return result;
+    }
+
+    /// <summary>Aligned variant of <see cref="ChunkTokens"/>: each chunk carries the start/last-start/approximate-end
+    /// offsets back into <paramref name="text"/>, so callers can recover the original substring via
+    /// <see cref="AlignedChunkHelpers.FromOriginal(AlignedString)"/>.</summary>
+    /// <inheritdoc cref="ChunkTokens"/>
+    public static List<AlignedString> ChunkTokensAligned(TokenizerBase tokenizer, string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+    {
+        if (tokenizer is null) throw new ArgumentNullException(nameof(tokenizer));
+        if (string.IsNullOrEmpty(text)) return new List<AlignedString>();
+
+        var maxTokens = tokenizer.MaxTokens;
+        if (chunkLength <= 0 || chunkLength > maxTokens) chunkLength = maxTokens;
+        if (chunkOverlap < 0 || chunkOverlap >= chunkLength) chunkOverlap = chunkLength / 5;
+
+        reportProgress?.Invoke(0.001f);
+
+        List<TokenizedTokenAligned> tokens;
+        checked
+        {
+            // Avoid tokenizing material that would be discarded when maxChunks is bounded.
+            if (maxChunks != int.MaxValue)
+            {
+                var charBudget = Math.Min(chunkLength * maxChunks * tokenizer.ApproxCharToTokenRatio, text.Length);
+                tokens = tokenizer.TokenizeRawAligned(text.AsSpan(0, charBudget));
+            }
+            else
+            {
+                tokens = tokenizer.TokenizeRawAligned(text);
+            }
+        }
+
+        reportProgress?.Invoke(0.002f);
+
+        var docs = new List<AlignedString>();
+        if (tokens.Count == 0) return docs;
+
+        int step = Math.Max(1, chunkLength - chunkOverlap);
+        int i = 0;
+        var sw = ValueStopwatch.StartNew();
+
+        while (true)
+        {
+            int end = Math.Min(tokens.Count, i + chunkLength);
+            if (end <= i) break;
+
+            var first = tokens[i];
+            var last = tokens[end - 1];
+
+            int s = Math.Max(0, first.Start);
+            int e = Math.Min(text.Length, last.ApproximateEnd);
+
+            if (e > s)
+            {
+                var value = text.Substring(s, e - s);
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    docs.Add(new AlignedString(value, s, last.Start, e, text));
+
+                    if (reportProgress is object && (sw.GetElapsedTime() > TimeSpan.FromMilliseconds(300)))
+                    {
+                        reportProgress(maxChunks == int.MaxValue ? (float)i / tokens.Count : (float)docs.Count / maxChunks);
+                        sw = ValueStopwatch.StartNew();
+                    }
+
+                    if (docs.Count >= maxChunks) return docs;
+                }
+            }
+
+            if (end >= tokens.Count) break;
+            i += step;
+        }
+
+        return docs;
+    }
+
+    /// <summary>Splits <paramref name="text"/> into BPE-token-bounded chunks and encodes each chunk to an embedding using
+    /// <paramref name="encoder"/>.</summary>
+    /// <inheritdoc cref="ISentenceEncoder.ChunkAndEncodeAsync"/>
+    public static async Task<EncodedChunk[]> ChunkAndEncodeAsync(ISentenceEncoder encoder, string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+    {
+        ClampChunkArgs(encoder, ref chunkLength, ref chunkOverlap);
+
+        var sw = ValueStopwatch.StartNew();
+        var chunks = ChunkTokens(encoder.Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress is object ? p => reportProgress(p * 0.5f) : null);
+        var encoded = new EncodedChunk[chunks.Count];
+
+        try
+        {
+            if (sequentially)
+            {
+                var one = new string[1];
+                for (int i = 0; i < chunks.Count; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    one[0] = chunks[i];
+                    var v = await encoder.EncodeAsync(one, cancellationToken);
+                    encoded[i] = new EncodedChunk(one[0], v[0]);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Count);
+                }
+            }
+            else
+            {
+                var vectors = await encoder.EncodeAsync(chunks.ToArray(), cancellationToken);
+                for (int i = 0; i < encoded.Length; i++)
+                {
+                    encoded[i] = new EncodedChunk(chunks[i], vectors[i]);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Count);
+                }
+            }
+        }
+        catch (Exception e) when (HandleCancellation(e, cancellationToken, keepResultsOnCancellation))
+        {
+            return encoded.Where(c => c.Text is not null).ToArray();
+        }
+
+        return encoded;
+    }
+
+    /// <summary>Aligned variant of <see cref="ChunkAndEncodeAsync"/>: each result carries offsets into <paramref name="text"/>.</summary>
+    /// <inheritdoc cref="ISentenceEncoder.ChunkAndEncodeAlignedAsync"/>
+    public static async Task<EncodedChunkAligned[]> ChunkAndEncodeAlignedAsync(ISentenceEncoder encoder, string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+    {
+        ClampChunkArgs(encoder, ref chunkLength, ref chunkOverlap);
+
+        var sw = ValueStopwatch.StartNew();
+        var chunks = ChunkTokensAligned(encoder.Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress is object ? p => reportProgress(p * 0.5f) : null);
+        var encoded = new EncodedChunkAligned[chunks.Count];
+
+        try
+        {
+            if (sequentially)
+            {
+                var one = new string[1];
+                for (int i = 0; i < chunks.Count; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    one[0] = chunks[i].Value;
+                    var v = await encoder.EncodeAsync(one, cancellationToken);
+                    encoded[i] = new EncodedChunkAligned(one[0], v[0], chunks[i].Start, chunks[i].LastStart, chunks[i].ApproximateEnd, text);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Count);
+                }
+            }
+            else
+            {
+                var vectors = await encoder.EncodeAsync(chunks.Select(c => c.Value).ToArray(), cancellationToken);
+                for (int i = 0; i < encoded.Length; i++)
+                {
+                    encoded[i] = new EncodedChunkAligned(chunks[i].Value, vectors[i], chunks[i].Start, chunks[i].LastStart, chunks[i].ApproximateEnd, text);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Count);
+                }
+            }
+        }
+        catch (Exception e) when (HandleCancellation(e, cancellationToken, keepResultsOnCancellation))
+        {
+            return encoded.Where(c => c.Text is not null).ToArray();
+        }
+
+        return encoded;
+    }
+
+    /// <summary>Chunks (using BPE offsets), strips injected markers from each chunk via
+    /// <paramref name="stripTags"/>, and encodes the cleaned text. The chunker treats markers as
+    /// ordinary tokens, so chunk boundaries are independent of which markers each chunk contains.</summary>
+    /// <param name="stripTags">Callback that strips markers from a chunk and produces a <see cref="TaggedChunk"/>.</param>
+    /// <inheritdoc cref="ISentenceEncoder.ChunkAndEncodeTaggedAsync"/>
+    public static async Task<TaggedEncodedChunk[]> ChunkAndEncodeTaggedAsync(ISentenceEncoder encoder, string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+    {
+        if (stripTags is null) throw new ArgumentNullException(nameof(stripTags));
+        ClampChunkArgs(encoder, ref chunkLength, ref chunkOverlap);
+
+        var sw = ValueStopwatch.StartNew();
+        var rawChunks = ChunkTokens(encoder.Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress is object ? p => reportProgress(p * 0.5f) : null);
+        var chunks = rawChunks.Select(c => stripTags(c)).ToArray();
+        var encoded = new TaggedEncodedChunk[chunks.Length];
+
+        try
+        {
+            if (sequentially)
+            {
+                var one = new string[1];
+                for (int i = 0; i < chunks.Length; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    one[0] = chunks[i].Text;
+                    var v = await encoder.EncodeAsync(one, cancellationToken);
+                    encoded[i] = new TaggedEncodedChunk(chunks[i].Text, v[0], chunks[i].Tag);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Length);
+                }
+            }
+            else
+            {
+                var vectors = await encoder.EncodeAsync(chunks.Select(c => c.Text).ToArray(), cancellationToken);
+                for (int i = 0; i < encoded.Length; i++)
+                {
+                    encoded[i] = new TaggedEncodedChunk(chunks[i].Text, vectors[i], chunks[i].Tag);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Length);
+                }
+            }
+        }
+        catch (Exception e) when (HandleCancellation(e, cancellationToken, keepResultsOnCancellation))
+        {
+            return encoded.Where(c => c.Text is not null).ToArray();
+        }
+
+        return encoded;
+    }
+
+    /// <summary>Aligned variant of <see cref="ChunkAndEncodeTaggedAsync"/>.</summary>
+    /// <param name="stripTags">Callback that strips markers from the original chunk substring and produces a <see cref="TaggedChunk"/>.</param>
+    /// <inheritdoc cref="ISentenceEncoder.ChunkAndEncodeTaggedAlignedAsync"/>
+    public static async Task<TaggedEncodedChunkAligned[]> ChunkAndEncodeTaggedAlignedAsync(ISentenceEncoder encoder, string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+    {
+        if (stripTags is null) throw new ArgumentNullException(nameof(stripTags));
+        ClampChunkArgs(encoder, ref chunkLength, ref chunkOverlap);
+
+        var sw = ValueStopwatch.StartNew();
+        var raw = ChunkTokensAligned(encoder.Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress is object ? p => reportProgress(p * 0.5f) : null);
+
+        var chunks = raw.Select(c =>
+        {
+            var t = stripTags(c.FromOriginal());
+            return new TaggedChunkAligned(t.Text, t.Tag, c.Start, c.LastStart, c.ApproximateEnd, text);
+        }).ToArray();
+
+        var encoded = new TaggedEncodedChunkAligned[chunks.Length];
+
+        try
+        {
+            if (sequentially)
+            {
+                var one = new string[1];
+                for (int i = 0; i < chunks.Length; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    one[0] = chunks[i].Text;
+                    var v = await encoder.EncodeAsync(one, cancellationToken);
+                    encoded[i] = new TaggedEncodedChunkAligned(chunks[i].Text, v[0], chunks[i].Tag, chunks[i].Start, chunks[i].LastStart, chunks[i].ApproximateEnd, text);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Length);
+                }
+            }
+            else
+            {
+                var vectors = await encoder.EncodeAsync(chunks.Select(c => c.Text).ToArray(), cancellationToken);
+                for (int i = 0; i < encoded.Length; i++)
+                {
+                    encoded[i] = new TaggedEncodedChunkAligned(chunks[i].Text, vectors[i], chunks[i].Tag, chunks[i].Start, chunks[i].LastStart, chunks[i].ApproximateEnd, text);
+                    MaybeReportProgress(reportProgress, ref sw, i, chunks.Length);
+                }
+            }
+        }
+        catch (Exception e) when (HandleCancellation(e, cancellationToken, keepResultsOnCancellation))
+        {
+            return encoded.Where(c => c.Text is not null).ToArray();
+        }
+
+        return encoded;
+    }
+
+    private static void ClampChunkArgs(ISentenceEncoder encoder, ref int chunkLength, ref int chunkOverlap)
+    {
+        if (chunkLength <= 0 || chunkLength > encoder.MaxChunkLength) chunkLength = encoder.MaxChunkLength;
+        if (chunkOverlap < 0 || chunkOverlap > chunkLength) chunkOverlap = chunkLength / 5;
+    }
+
+    private static void MaybeReportProgress(Action<float> reportProgress, ref ValueStopwatch sw, int i, int total)
+    {
+        if (reportProgress is object && (sw.GetElapsedTime() > TimeSpan.FromMilliseconds(300)))
+        {
+            reportProgress(((float)i / Math.Max(1, total)) * 0.5f + 0.5f);
+            sw = ValueStopwatch.StartNew();
+        }
+    }
+
+    private static bool HandleCancellation(Exception e, CancellationToken cancellationToken, bool keepResultsOnCancellation)
+    {
+        return keepResultsOnCancellation && (e is OperationCanceledException || cancellationToken.IsCancellationRequested);
+    }
+}

--- a/SentenceTransformers/src/ISentenceEncoder.cs
+++ b/SentenceTransformers/src/ISentenceEncoder.cs
@@ -3,20 +3,82 @@ using Mosaik.Core;
 
 namespace SentenceTransformers;
 
+/// <summary>A chunk of text paired with its embedding vector.</summary>
+/// <param name="Text">The chunk text that was encoded.</param>
+/// <param name="Vector">Embedding vector produced for <paramref name="Text"/>.</param>
 public record struct EncodedChunk(string              Text, float[] Vector);
+
+/// <summary>A chunk of text paired with its embedding vector and offsets back into the original input.</summary>
+/// <param name="Text">The chunk text that was encoded (may have markers stripped).</param>
+/// <param name="Vector">Embedding vector produced for <paramref name="Text"/>.</param>
+/// <param name="Start">Character offset of the first token of the chunk in <paramref name="OriginalText"/>.</param>
+/// <param name="LastStart">Character offset of the last token of the chunk in <paramref name="OriginalText"/>.</param>
+/// <param name="ApproximateEnd">Approximate end-of-chunk character offset in <paramref name="OriginalText"/>.</param>
+/// <param name="OriginalText">The full source text the chunk was extracted from.</param>
 public record struct EncodedChunkAligned(string       Text, float[] Vector, int    Start, int LastStart, int ApproximateEnd, string OriginalText);
+
+/// <summary>
+/// A chunk + embedding + tag. The tag is the metadata produced by a <see cref="ISentenceEncoder"/>
+/// tagged-chunking call (for example, the page numbers extracted from injected page markers).
+/// </summary>
+/// <param name="Text">The chunk text that was encoded (markers removed).</param>
+/// <param name="Vector">Embedding vector produced for <paramref name="Text"/>.</param>
+/// <param name="Tag">Tag value derived from the markers found inside the chunk.</param>
 public record struct TaggedEncodedChunk(string        Text, float[] Vector, string Tag);
+
+/// <summary>Aligned tagged chunk: a <see cref="TaggedEncodedChunk"/> plus offsets into the original input.</summary>
 public record struct TaggedEncodedChunkAligned(string Text, float[] Vector, string Tag, int Start, int LastStart, int ApproximateEnd, string OriginalText);
+
+/// <summary>
+/// Result of stripping injected markers out of a chunk: the cleaned text plus a tag derived from the
+/// markers. Returned by the <c>stripTags</c> callback passed to the tagged chunking helpers.
+/// </summary>
+/// <param name="Text">The chunk text with markers removed.</param>
+/// <param name="Tag">Tag derived from the markers (for example, a page range).</param>
 public record struct TaggedChunk(string               Text, string  Tag);
+
+/// <summary>Aligned variant of <see cref="TaggedChunk"/> carrying offsets into the original input.</summary>
 public record struct TaggedChunkAligned(string        Text, string  Tag, int Start, int LastStart, int ApproximateEnd, string OriginalText);
+
+/// <summary>
+/// Common contract for sentence encoders. Provides <see cref="EncodeAsync"/> for direct batch
+/// embedding plus a family of default-implementation helpers for tokenizer-aware text chunking,
+/// optionally combined with marker-injection / marker-stripping flows. The chunking helpers split
+/// long text on token boundaries (so chunks never exceed the model's context window) and can encode
+/// each chunk to a vector in a single call.
+/// </summary>
 public interface ISentenceEncoder: IDisposable
 {
+    /// <summary>
+    /// Maximum number of tokens (including special tokens) the underlying model accepts per call.
+    /// Chunking helpers clamp <c>chunkLength</c> to this value.
+    /// </summary>
     public int MaxChunkLength { get; }
 
+    /// <summary>The tokenizer used to split text into tokens for chunking and encoding.</summary>
     public TokenizerBase Tokenizer { get; }
 
+    /// <summary>
+    /// Encodes a batch of input strings into embedding vectors. Each input must fit in
+    /// <see cref="MaxChunkLength"/> tokens (use one of the <c>ChunkAndEncode*</c> helpers when it does not).
+    /// </summary>
+    /// <param name="sentences">Texts to embed.</param>
+    /// <param name="cancellationToken">Token used to terminate the inference run early.</param>
+    /// <returns>One embedding vector per input sentence, in the same order.</returns>
     public Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Splits <paramref name="text"/> into token-bounded chunks and encodes each chunk to an embedding.
+    /// </summary>
+    /// <param name="text">Source text. May be longer than <see cref="MaxChunkLength"/>.</param>
+    /// <param name="chunkLength">Maximum tokens per chunk. Values <c>&lt;= 0</c> or above <see cref="MaxChunkLength"/> are clamped to <see cref="MaxChunkLength"/>.</param>
+    /// <param name="chunkOverlap">Number of tokens to overlap between consecutive chunks. Out-of-range values default to <c>chunkLength / 5</c>.</param>
+    /// <param name="sequentially">When true, encode chunks one-by-one (lower peak memory, supports incremental cancellation). When false, encode the whole batch in a single call.</param>
+    /// <param name="maxChunks">Hard cap on the number of chunks to produce.</param>
+    /// <param name="keepResultsOnCancellation">When true and the operation is cancelled, return the chunks that finished encoding instead of throwing.</param>
+    /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+    /// <param name="cancellationToken">Cancellation token for the encoding loop.</param>
+    /// <returns>Array of <see cref="EncodedChunk"/>, one per produced chunk, in source order.</returns>
     public async Task<EncodedChunk[]> ChunkAndEncodeAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
     {
         if (chunkLength <= 0 || chunkLength > MaxChunkLength)
@@ -86,6 +148,12 @@ public interface ISentenceEncoder: IDisposable
         return encodedChunks;
     }
 
+    /// <summary>
+    /// Same as <see cref="ChunkAndEncodeAsync"/> but each result also exposes character offsets back
+    /// into <paramref name="text"/>, allowing the original (un-normalized) substring to be recovered
+    /// via <see cref="AlignedChunkHelpers.FromOriginal(EncodedChunkAligned)"/>.
+    /// </summary>
+    /// <inheritdoc cref="ChunkAndEncodeAsync"/>
     public async Task<EncodedChunkAligned[]> ChunkAndEncodeAlignedAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
     {
         if (chunkLength <= 0 || chunkLength > MaxChunkLength)
@@ -154,6 +222,21 @@ public interface ISentenceEncoder: IDisposable
         return encodedChunks;
     }
 
+    /// <summary>
+    /// Chunks <paramref name="text"/> on token boundaries, then for each chunk invokes
+    /// <paramref name="stripTags"/> to extract a tag and remove injected markers before encoding.
+    /// </summary>
+    /// <remarks>
+    /// This supports the "marker injection / marker removal" workflow: callers pre-process the
+    /// source text to embed lightweight markers (for example, page boundaries written as
+    /// <c>⁎12⁑</c>), pass the marked text in here, and <paramref name="stripTags"/> recovers the
+    /// page numbers as the <see cref="TaggedChunk.Tag"/> while returning the cleaned text that is
+    /// actually fed to the model. The chunker treats markers as ordinary tokens, so chunk boundaries
+    /// are independent of which page a chunk happens to cover.
+    /// </remarks>
+    /// <param name="text">Source text, optionally with injected markers.</param>
+    /// <param name="stripTags">Callback that removes injected markers from a chunk and returns the cleaned text plus a tag derived from those markers.</param>
+    /// <inheritdoc cref="ChunkAndEncodeAsync"/>
     public async Task<TaggedEncodedChunk[]> ChunkAndEncodeTaggedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
     {
         if (chunkLength <= 0 || chunkLength > MaxChunkLength)
@@ -224,6 +307,15 @@ public interface ISentenceEncoder: IDisposable
         return encodedChunks;
     }
 
+    /// <summary>
+    /// Aligned variant of <see cref="ChunkAndEncodeTaggedAsync"/>: chunks the (marked) text on token
+    /// boundaries, then for each chunk extracts the original (unmarked) substring via the aligned
+    /// tokenizer, runs <paramref name="stripTags"/> on it, and encodes the cleaned text. Results
+    /// carry offsets back into <paramref name="text"/>.
+    /// </summary>
+    /// <param name="text">Source text, optionally with injected markers.</param>
+    /// <param name="stripTags">Callback that removes injected markers and produces a tag from the chunk.</param>
+    /// <inheritdoc cref="ChunkAndEncodeAsync"/>
     public async Task<TaggedEncodedChunkAligned[]> ChunkAndEncodeTaggedAlignedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
     {
         if (chunkLength <= 0 || chunkLength > MaxChunkLength)
@@ -299,6 +391,19 @@ public interface ISentenceEncoder: IDisposable
         return encodedChunks;
     }
 
+    /// <summary>
+    /// Tokenizes <paramref name="text"/> and merges tokens into chunks of at most
+    /// <paramref name="chunkLength"/> tokens with <paramref name="chunkOverlap"/> tokens of overlap
+    /// between consecutive chunks. The text is first truncated to roughly
+    /// <c>chunkLength * maxChunks * Tokenizer.ApproxCharToTokenRatio</c> characters when
+    /// <paramref name="maxChunks"/> is bounded, to avoid tokenizing material that would be dropped.
+    /// </summary>
+    /// <param name="text">Source text to chunk.</param>
+    /// <param name="chunkLength">Maximum tokens per chunk.</param>
+    /// <param name="chunkOverlap">Tokens of overlap kept between consecutive chunks.</param>
+    /// <param name="maxChunks">Hard cap on the number of chunks returned.</param>
+    /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+    /// <returns>The chunks as untokenized strings, in source order.</returns>
     public List<string> ChunkTokens(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
     {
         reportProgress?.Invoke(0.001f);
@@ -311,6 +416,12 @@ public interface ISentenceEncoder: IDisposable
         }
     }
 
+    /// <summary>
+    /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries character offsets back into
+    /// the (possibly truncated) source text, so callers can recover the exact original substring via
+    /// <see cref="AlignedChunkHelpers.FromOriginal(AlignedString)"/>.
+    /// </summary>
+    /// <inheritdoc cref="ChunkTokens"/>
     public List<AlignedString> ChunkTokensAligned(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
     {
         checked //Ensure the max text substring length computed is not overflowing
@@ -422,6 +533,16 @@ public interface ISentenceEncoder: IDisposable
         return docs;
     }
 
+    /// <summary>
+    /// Character-based fallback chunker that does not require a tokenizer. Splits on whitespace and
+    /// rejoins runs of tokens into chunks of at most <paramref name="chunkLength"/> characters with
+    /// <paramref name="chunkOverlap"/> characters of overlap.
+    /// </summary>
+    /// <param name="text">Source text to chunk.</param>
+    /// <param name="separator">Separator used when re-joining whitespace-split tokens.</param>
+    /// <param name="chunkLength">Maximum characters per chunk.</param>
+    /// <param name="chunkOverlap">Characters of overlap between consecutive chunks.</param>
+    /// <param name="maxChunks">Hard cap on the number of chunks returned.</param>
     public static List<string> ChunkString(string text, char separator = ' ', int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue)
     {
         return MergeStringSplits(text.Split(new char[] { '\n', '\r', ' ' }, StringSplitOptions.RemoveEmptyEntries), separator, chunkLength, chunkOverlap, maxChunks);


### PR DESCRIPTION
## Summary

This PR introduces specialized chunking and encoding helpers for byte-level BPE tokenizers (Qwen, Harrier, and similar Hugging Face `tokenizer.json`-driven encoders). The new `BPEChunkAndEncodeHelpers` class provides offset-based chunk reconstruction that preserves exact whitespace and injected markers, replacing the WordPiece-oriented approach that relied on subword markers (`##`) and token concatenation.

## Key Changes

- **New `BPEChunkAndEncodeHelpers` class** (`SentenceTransformers/src/BPEChunkAndEncodeHelpers.cs`):
  - `ChunkTokens()` and `ChunkTokensAligned()`: Tokenize text and split into overlapping chunks using BPE token offsets
  - `ChunkAndEncodeAsync()` and `ChunkAndEncodeAlignedAsync()`: Chunk text and encode each chunk to embeddings
  - `ChunkAndEncodeTaggedAsync()` and `ChunkAndEncodeTaggedAlignedAsync()`: Support marker-injection/marker-stripping workflows for extracting metadata (e.g., page numbers) from chunks
  - All methods support sequential or batched encoding, progress reporting, cancellation with partial results, and configurable chunk overlap

- **Enhanced `ISentenceEncoder` interface** (`SentenceTransformers/src/ISentenceEncoder.cs`):
  - Added comprehensive XML documentation to all record types and interface members
  - Clarified the contract for `MaxChunkLength`, `Tokenizer`, and `EncodeAsync()`
  - Documented the marker-injection workflow and aligned offset tracking

- **Concrete implementations** in Harrier, Qwen3, MiniLM, and ArcticXs:
  - Added wrapper methods that delegate to `BPEChunkAndEncodeHelpers` for BPE-based encoders (Harrier, Qwen3)
  - Added XML documentation to class and constructor definitions for all encoder implementations

## Implementation Details

- **Offset-based reconstruction**: Chunks are extracted by slicing the source text between the first and last token's character offsets, avoiding the need for subword markers and preserving exact whitespace and punctuation
- **Marker preservation**: Injected markers (e.g., `⁎12⁑` for page boundaries) are treated as ordinary tokens by the chunker, so chunk boundaries are independent of marker placement
- **Efficient tokenization**: When `maxChunks` is bounded, the tokenizer only processes a character budget proportional to the expected output, avoiding unnecessary work
- **Progress reporting**: Throttled to 300ms intervals to avoid excessive callback overhead
- **Cancellation handling**: Supports early termination with optional retention of already-encoded chunks

https://claude.ai/code/session_01UEneALWeexp9uiBsJwArtd