### PR TITLE
Add Harrier project to the NuGet publish pipeline

### DIFF
--- a/.devops/azure-pipelines.yml
+++ b/.devops/azure-pipelines.yml
@@ -3,6 +3,7 @@ variables:
   projectMiniLM:   './SentenceTransformers.MiniLM/SentenceTransformers.MiniLM.csproj'
   projectArticXs:  './SentenceTransformers.ArcticXs/SentenceTransformers.ArcticXs.csproj'
   projectQwen3:    './SentenceTransformers.Qwen3/SentenceTransformers.Qwen3.csproj'
+  projectHarrier:  './SentenceTransformers.Harrier/SentenceTransformers.Harrier.csproj'
   solution:        './SentenceTransformers.sln'
   buildConfiguration: 'Release'
   targetVersion: yy.M.$(build.buildId)
@@ -71,6 +72,13 @@ steps:
   inputs:
     command: 'build'
     projects: '$(projectQwen3)'
+    arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)  /p:GeneratePackageOnBuild=true'
+
+- task: DotNetCoreCLI@2
+  displayName: 'build Harrier project'
+  inputs:
+    command: 'build'
+    projects: '$(projectHarrier)'
     arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)  /p:GeneratePackageOnBuild=true'
 
 - task: NuGetCommand@2


### PR DESCRIPTION
## What

Wire the **Harrier** (`harrier-oss-v1-0.6b`) multilingual embeddings model project into the NuGet publish pipeline (`.devops/azure-pipelines.yml`).

## Why

The `SentenceTransformers.Harrier` project was added to the repo (PR #9) but was never added to the publish pipeline, so its NuGet package was never built or pushed. As a result `SentenceTransformers.Harrier` does not exist on the feed, while its sibling `SentenceTransformers.Qwen3` (PR #6) is published (it *was* added to the pipeline).

This blocks wiring Harrier into downstream consumers (e.g. `mosaik`, where we're adding per-model vector-indexing support).

## Change

- Add a `projectHarrier` pipeline variable.
- Add a `build Harrier project` step with `/p:GeneratePackageOnBuild=true`, mirroring the existing Qwen3 step. The existing `push all nuget packages` step (`**/*.nupkg`) then publishes it.

## Follow-up

Once this runs on `main` and `SentenceTransformers.Harrier` is published, the `mosaik` side will pin the resulting package version to enable the Harrier encoder.

https://claude.ai/code/session_01Mw5rQmDKvJiy5nN4cjkwWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw5rQmDKvJiy5nN4cjkwWS)_