### PR TITLE
Embed tokenizer.json so Qwen3/Harrier work as NuGet packages

### DIFF
--- a/SentenceTransformers.Harrier/SentenceTransformers.Harrier.csproj
+++ b/SentenceTransformers.Harrier/SentenceTransformers.Harrier.csproj
@@ -33,5 +33,7 @@
 
   <ItemGroup>
     <None Include="Resources\tokenizer.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <!-- Also embed the tokenizer so NuGet consumers work without copying Resources/tokenizer.json into their output. -->
+    <EmbeddedResource Include="Resources\tokenizer.json" />
   </ItemGroup>
 </Project>

--- a/SentenceTransformers.Harrier/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier/src/SentenceEncoder.cs
@@ -122,7 +122,12 @@ namespace SentenceTransformers.Harrier
             return new[] { preferred };
         }
 
-        /// <summary>Resolves tokenizer path: Resources/tokenizer.json (under app base directory).</summary>
+        /// <summary>
+        /// Resolves the tokenizer.json path. Prefers <c>Resources/tokenizer.json</c> next to the application
+        /// (under the app base directory); when that is missing - e.g. when this library is consumed as a NuGet
+        /// package and the consumer did not copy the file to its output - it falls back to the copy embedded in
+        /// this assembly, extracting it once to a temp location.
+        /// </summary>
         private static string ResolveTokenizerPath(string modelOnnxPath)
         {
             var resourcesPath = Path.Combine(AppContext.BaseDirectory, "Resources", "tokenizer.json");
@@ -131,7 +136,27 @@ namespace SentenceTransformers.Harrier
                 return resourcesPath;
             }
 
-            throw new FileNotFoundException(resourcesPath);
+            return ExtractEmbeddedTokenizer();
+        }
+
+        /// <summary>Writes the embedded tokenizer.json to a stable temp path (once) and returns it.</summary>
+        private static string ExtractEmbeddedTokenizer()
+        {
+            var bytes = ResourceLoader.GetResource(typeof(SentenceEncoder).Assembly, "tokenizer.json");
+            if (bytes is null)
+            {
+                throw new FileNotFoundException("tokenizer.json was not found on disk or embedded in the SentenceTransformers.Harrier assembly.");
+            }
+
+            var cachedPath = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier", "tokenizer.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(cachedPath)!);
+
+            if (!File.Exists(cachedPath) || new FileInfo(cachedPath).Length != bytes.Length)
+            {
+                File.WriteAllBytes(cachedPath, bytes);
+            }
+
+            return cachedPath;
         }
 
         public void Dispose()

--- a/SentenceTransformers.Qwen3/SentenceTransformers.Qwen3.csproj
+++ b/SentenceTransformers.Qwen3/SentenceTransformers.Qwen3.csproj
@@ -33,5 +33,7 @@
 
   <ItemGroup>
     <None Include="Resources\tokenizer.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <!-- Also embed the tokenizer so NuGet consumers work without copying Resources/tokenizer.json into their output. -->
+    <EmbeddedResource Include="Resources\tokenizer.json" />
   </ItemGroup>
 </Project>

--- a/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
@@ -83,7 +83,12 @@ namespace SentenceTransformers.Qwen3
             Tokenizer = new QwenTokenizer(tokPathToUse, MaxChunkLength);
         }
 
-        /// <summary>Resolves tokenizer path: Resources/tokenizer.json (under app base directory), or embedded resource written to temp if not found.</summary>
+        /// <summary>
+        /// Resolves the tokenizer.json path. Prefers <c>Resources/tokenizer.json</c> next to the application
+        /// (under the app base directory); when that is missing - e.g. when this library is consumed as a NuGet
+        /// package and the consumer did not copy the file to its output - it falls back to the copy embedded in
+        /// this assembly, extracting it once to a temp location.
+        /// </summary>
         private static string ResolveTokenizerPath(string modelOnnxPath)
         {
             var resourcesPath = Path.Combine(AppContext.BaseDirectory, "Resources", "tokenizer.json");
@@ -92,7 +97,27 @@ namespace SentenceTransformers.Qwen3
                 return resourcesPath;
             }
 
-            throw new FileNotFoundException(resourcesPath);
+            return ExtractEmbeddedTokenizer();
+        }
+
+        /// <summary>Writes the embedded tokenizer.json to a stable temp path (once) and returns it.</summary>
+        private static string ExtractEmbeddedTokenizer()
+        {
+            var bytes = ResourceLoader.GetResource(typeof(SentenceEncoder).Assembly, "tokenizer.json");
+            if (bytes is null)
+            {
+                throw new FileNotFoundException("tokenizer.json was not found on disk or embedded in the SentenceTransformers.Qwen3 assembly.");
+            }
+
+            var cachedPath = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Qwen3", "tokenizer.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(cachedPath)!);
+
+            if (!File.Exists(cachedPath) || new FileInfo(cachedPath).Length != bytes.Length)
+            {
+                File.WriteAllBytes(cachedPath, bytes);
+            }
+
+            return cachedPath;
         }
 
         public void Dispose()


### PR DESCRIPTION
## Problem

Creating an embedding index with **Harrier** (and the same applies to **Qwen3**) throws at runtime in a NuGet consumer:

```
System.IO.FileNotFoundException: ...\bin\Debug\net10.0-windows10.0.19041.0\win-x64\Resources\tokenizer.json
   at SentenceTransformers.Harrier.SentenceEncoder.ResolveTokenizerPath(String modelOnnxPath)
   at SentenceTransformers.Harrier.SentenceEncoder..ctor(...)
   at SentenceTransformers.Harrier.SentenceEncoder.CreateAsync(...)
```

## Root cause

Both encoders load `tokenizer.json` from `<AppBaseDir>/Resources/tokenizer.json` at runtime, but the file is shipped only as:

```xml
<None Include="Resources\tokenizer.json" CopyToOutputDirectory="PreserveNewest" ... />
```

`<None CopyToOutputDirectory>` copies the file to **the library's own** build output, but it does **not** flow to downstream **NuGet consumers**. So an app that references the package (e.g. `Mosaik.Server`) has no `Resources/tokenizer.json`, and `ResolveTokenizerPath` throws. (Qwen3's doc-comment already claimed an embedded fallback, but the code still just threw.)

## Fix

Embed `tokenizer.json` as an `EmbeddedResource` (mirroring how the MiniLM/Arctic XS models embed their weights), and have `ResolveTokenizerPath` fall back to it when the on-disk copy is absent — extracting the embedded copy to a temp file once and reusing it. Done for **both** Harrier and Qwen3.

- On-disk `Resources/tokenizer.json` is still preferred when present (lets consumers override).
- The embedded resource names resolve to `SentenceTransformers.Harrier.Resources.tokenizer.json` / `SentenceTransformers.Qwen3.Resources.tokenizer.json`, which exactly match `ResourceLoader`'s lookup — **verified** by reflecting over the built assemblies.
- Both projects build with **0 errors**.

## Follow-up

This needs a new published package version (pipeline run on `main`). Once published, the `mosaik` consumer's `SentenceTransformers.{Qwen3,Harrier}` references should be bumped to it.

https://claude.ai/code/session_01Mw5rQmDKvJiy5nN4cjkwWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw5rQmDKvJiy5nN4cjkwWS)_