### PR TITLE
Add Harrier.Small (270m), rename Harrier to Harrier.Medium

### DIFF
--- a/.devops/azure-pipelines.yml
+++ b/.devops/azure-pipelines.yml
@@ -1,10 +1,11 @@
 variables:
-  projectBase:     './SentenceTransformers/SentenceTransformers.csproj'
-  projectMiniLM:   './SentenceTransformers.MiniLM/SentenceTransformers.MiniLM.csproj'
-  projectArticXs:  './SentenceTransformers.ArcticXs/SentenceTransformers.ArcticXs.csproj'
-  projectQwen3:    './SentenceTransformers.Qwen3/SentenceTransformers.Qwen3.csproj'
-  projectHarrier:  './SentenceTransformers.Harrier/SentenceTransformers.Harrier.csproj'
-  solution:        './SentenceTransformers.sln'
+  projectBase:           './SentenceTransformers/SentenceTransformers.csproj'
+  projectMiniLM:         './SentenceTransformers.MiniLM/SentenceTransformers.MiniLM.csproj'
+  projectArticXs:        './SentenceTransformers.ArcticXs/SentenceTransformers.ArcticXs.csproj'
+  projectQwen3:          './SentenceTransformers.Qwen3/SentenceTransformers.Qwen3.csproj'
+  projectHarrierMedium:  './SentenceTransformers.Harrier.Medium/SentenceTransformers.Harrier.Medium.csproj'
+  projectHarrierSmall:   './SentenceTransformers.Harrier.Small/SentenceTransformers.Harrier.Small.csproj'
+  solution:              './SentenceTransformers.sln'
   buildConfiguration: 'Release'
   targetVersion: yy.M.$(build.buildId)
   
@@ -75,10 +76,17 @@ steps:
     arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)  /p:GeneratePackageOnBuild=true'
 
 - task: DotNetCoreCLI@2
-  displayName: 'build Harrier project'
+  displayName: 'build Harrier.Medium project'
   inputs:
     command: 'build'
-    projects: '$(projectHarrier)'
+    projects: '$(projectHarrierMedium)'
+    arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)  /p:GeneratePackageOnBuild=true'
+
+- task: DotNetCoreCLI@2
+  displayName: 'build Harrier.Small project'
+  inputs:
+    command: 'build'
+    projects: '$(projectHarrierSmall)'
     arguments: '-c $(buildConfiguration) /p:Version=$(targetVersion)  /p:GeneratePackageOnBuild=true'
 
 - task: NuGetCommand@2

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ float[][] vectors = await encoder.EncodeAsync(new[]
 | [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.MiniLM.svg?label=SentenceTransformers.MiniLM)](https://www.nuget.org/packages/SentenceTransformers.MiniLM/) | [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) | 384 | 256 | English | Embedded |
 | [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.ArcticXs.svg?label=SentenceTransformers.ArcticXs)](https://www.nuget.org/packages/SentenceTransformers.ArcticXs/) | [snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs) | 384 | 512 | English | Embedded |
 | [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Qwen3.svg?label=SentenceTransformers.Qwen3)](https://www.nuget.org/packages/SentenceTransformers.Qwen3/) | [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) | 1024 | 32768 | Multilingual | Downloaded on first use |
-| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.svg?label=SentenceTransformers.Harrier)](https://www.nuget.org/packages/SentenceTransformers.Harrier/) | [harrier-oss-v1-0.6b](https://huggingface.co/onnx-community/harrier-oss-v1-0.6b-ONNX) | 1024 | 32768 | Multilingual | Downloaded on first use |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.Medium.svg?label=SentenceTransformers.Harrier.Medium)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Medium/) | [harrier-oss-v1-0.6b](https://huggingface.co/onnx-community/harrier-oss-v1-0.6b-ONNX) | 1024 | 32768 | Multilingual | Downloaded on first use |
 | [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.Small.svg?label=SentenceTransformers.Harrier.Small)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Small/) | [harrier-oss-v1-270m](https://huggingface.co/onnx-community/harrier-oss-v1-270m-ONNX) | 640 | 32768 | Multilingual | Downloaded on first use |
 
 - **Embedded** models bundle the ONNX weights inside the NuGet package, so the encoder is ready
@@ -52,9 +52,9 @@ float[][] vectors = await encoder.EncodeAsync(new[]
   (under the system temp folder by default — see [Choosing where weights are stored](#choosing-where-weights-are-stored)).
 
 Pick **MiniLM** for the smallest/fastest footprint, **Arctic XS** for a strong English default,
-**Harrier Small** when you need multilingual coverage without paying for the larger Harrier 0.6b,
-and **Qwen3** or **Harrier** when you want the highest-quality embeddings (1024 dim) and the full
-32k-token context window.
+**Harrier Small** when you need multilingual coverage without paying for the larger 0.6b weights,
+and **Qwen3** or **Harrier Medium** when you want the highest-quality embeddings (1024 dim) and
+the full 32k-token context window.
 
 ## Installation
 
@@ -65,7 +65,7 @@ dependency):
 dotnet add package SentenceTransformers.MiniLM
 dotnet add package SentenceTransformers.ArcticXs
 dotnet add package SentenceTransformers.Qwen3
-dotnet add package SentenceTransformers.Harrier
+dotnet add package SentenceTransformers.Harrier.Medium
 dotnet add package SentenceTransformers.Harrier.Small
 ```
 
@@ -89,7 +89,7 @@ float[][] vectors = await encoder.EncodeAsync(new[]
 });
 ```
 
-### Downloaded models (Qwen3, Harrier, Harrier Small)
+### Downloaded models (Qwen3, Harrier Medium, Harrier Small)
 
 Larger models download their ONNX weights on first use. Create them with the async `CreateAsync`
 factory — the download is cached, so subsequent runs are instant:
@@ -104,10 +104,10 @@ float[][] vectors = await encoder.EncodeAsync(new[] { "Hello world" });
 // vectors[0] is a float[1024]
 ```
 
-Harrier is multilingual:
+Harrier Medium is multilingual:
 
 ```csharp
-using SentenceTransformers.Harrier;
+using SentenceTransformers.Harrier.Medium;
 
 using var encoder = await SentenceEncoder.CreateAsync();
 
@@ -123,7 +123,7 @@ Harrier Small is the same multilingual family at ~270M parameters (640-dim embed
 suitable when you want multilingual coverage without paying for the 0.6b weights:
 
 ```csharp
-using SentenceTransformers.HarrierSmall;
+using SentenceTransformers.Harrier.Small;
 
 using var encoder = await SentenceEncoder.CreateAsync();
 
@@ -196,7 +196,7 @@ using var encoder = await SentenceTransformers.Qwen3.SentenceEncoder.CreateAsync
     downloadToPath: "/var/models/qwen3.onnx");
 
 // Or point at your own mirror:
-using var harrier = await SentenceTransformers.Harrier.SentenceEncoder.CreateAsync(
+using var harrier = await SentenceTransformers.Harrier.Medium.SentenceEncoder.CreateAsync(
     modelUrl:     "https://my-mirror.example.com/harrier/model_quantized.onnx",
     modelDataUrl: "https://my-mirror.example.com/harrier/model_quantized.onnx_data");
 ```
@@ -206,26 +206,25 @@ to tune threading or enable hardware execution providers.
 
 ### Choosing a Harrier quantization
 
-The Hugging Face ONNX exports of both Harrier variants ship multiple quantization formats — pick
-the one that fits your CPU / GPU memory budget. URLs for every variant are exposed as constants on
-`SentenceEncoder.Quantizations`:
+Both Harrier packages ship multiple quantization formats — pick the one that fits your CPU / GPU
+memory budget. URLs for every variant are exposed as constants on `SentenceEncoder.Quantizations`:
 
-| Variant     | Constant                                | Harrier 0.6b weights | Harrier Small (270m) weights |
-| ---         | ---                                     | ---:                 | ---:                          |
-| Full (fp32) | `Quantizations.FullModelUrl`            | 2.09 GB (+306 MB)    | 1.11 GB                       |
-| FP16        | `Quantizations.Fp16ModelUrl`            | 1.20 GB              | 553 MB                        |
-| Q4          | `Quantizations.Q4ModelUrl`              | 399 MB               | 205 MB                        |
-| Q4 + FP16   | `Quantizations.Q4Fp16ModelUrl`          | 353 MB               | 172 MB                        |
-| Quantized   | `Quantizations.QuantizedModelUrl` *(default)* | 706 MB         | 344 MB                        |
+| Variant     | Constant                                | Harrier Medium (0.6b) weights | Harrier Small (270m) weights |
+| ---         | ---                                     | ---:                          | ---:                          |
+| Full (fp32) | `Quantizations.FullModelUrl`            | 2.09 GB (+306 MB)             | 1.11 GB                       |
+| FP16        | `Quantizations.Fp16ModelUrl`            | 1.20 GB                       | 553 MB                        |
+| Q4          | `Quantizations.Q4ModelUrl`              | 399 MB                        | 205 MB                        |
+| Q4 + FP16   | `Quantizations.Q4Fp16ModelUrl`          | 353 MB                        | 172 MB                        |
+| Quantized   | `Quantizations.QuantizedModelUrl` *(default)* | 706 MB                  | 344 MB                        |
 
 `Quantized` is the default — it produces float32 output and is the most broadly compatible across
 ONNX Runtime execution providers. `Q4` / `Q4F16` are the smallest on disk; `FP16` keeps the most
 precision per byte; `Full` is the unquantized reference. Each entry has a matching
-`…ModelDataUrl` constant for the external weights file (and the 0.6b `Full` variant additionally
-has `FullModelDataUrl2` because its fp32 weights are split into two files).
+`…ModelDataUrl` constant for the external weights file (and the Harrier Medium `Full` variant
+additionally has `FullModelDataUrl2` because its fp32 weights are split into two files).
 
 ```csharp
-using SentenceTransformers.HarrierSmall;
+using SentenceTransformers.Harrier.Small;
 
 // Use the smallest variant available (Q4F16, ~172 MB):
 using var encoder = await SentenceEncoder.CreateAsync(
@@ -238,7 +237,7 @@ using var encoder = await SentenceEncoder.CreateAsync(
 Each model package contains:
 
 - a tokenizer (WordPiece for the BERT-family embedded models, BPE via Hugging Face tokenizers for the
-  Qwen3 / Harrier models),
+  Qwen3 / Harrier Medium / Harrier Small models),
 - the ONNX graph (embedded, or downloaded on first use), and
 - a thin `SentenceEncoder` that tokenizes, runs ONNX Runtime inference, pools the token outputs and
   L2-normalizes the result.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ float[][] vectors = await encoder.EncodeAsync(new[]
 | [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.ArcticXs.svg?label=SentenceTransformers.ArcticXs)](https://www.nuget.org/packages/SentenceTransformers.ArcticXs/) | [snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs) | 384 | 512 | English | Embedded |
 | [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Qwen3.svg?label=SentenceTransformers.Qwen3)](https://www.nuget.org/packages/SentenceTransformers.Qwen3/) | [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) | 1024 | 32768 | Multilingual | Downloaded on first use |
 | [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.svg?label=SentenceTransformers.Harrier)](https://www.nuget.org/packages/SentenceTransformers.Harrier/) | [harrier-oss-v1-0.6b](https://huggingface.co/onnx-community/harrier-oss-v1-0.6b-ONNX) | 1024 | 32768 | Multilingual | Downloaded on first use |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.Small.svg?label=SentenceTransformers.Harrier.Small)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Small/) | [harrier-oss-v1-270m](https://huggingface.co/onnx-community/harrier-oss-v1-270m-ONNX) | 640 | 32768 | Multilingual | Downloaded on first use |
 
 - **Embedded** models bundle the ONNX weights inside the NuGet package, so the encoder is ready
   immediately after construction.
@@ -51,7 +52,9 @@ float[][] vectors = await encoder.EncodeAsync(new[]
   (under the system temp folder by default — see [Choosing where weights are stored](#choosing-where-weights-are-stored)).
 
 Pick **MiniLM** for the smallest/fastest footprint, **Arctic XS** for a strong English default,
-and **Qwen3** or **Harrier** when you need a larger context window or multilingual coverage.
+**Harrier Small** when you need multilingual coverage without paying for the larger Harrier 0.6b,
+and **Qwen3** or **Harrier** when you want the highest-quality embeddings (1024 dim) and the full
+32k-token context window.
 
 ## Installation
 
@@ -63,6 +66,7 @@ dotnet add package SentenceTransformers.MiniLM
 dotnet add package SentenceTransformers.ArcticXs
 dotnet add package SentenceTransformers.Qwen3
 dotnet add package SentenceTransformers.Harrier
+dotnet add package SentenceTransformers.Harrier.Small
 ```
 
 Targets **.NET 10**.
@@ -85,7 +89,7 @@ float[][] vectors = await encoder.EncodeAsync(new[]
 });
 ```
 
-### Downloaded models (Qwen3, Harrier)
+### Downloaded models (Qwen3, Harrier, Harrier Small)
 
 Larger models download their ONNX weights on first use. Create them with the async `CreateAsync`
 factory — the download is cached, so subsequent runs are instant:
@@ -113,6 +117,23 @@ float[][] vectors = await encoder.EncodeAsync(new[]
     "Buenos días",    // Spanish
     "おはよう",          // Japanese
 });
+```
+
+Harrier Small is the same multilingual family at ~270M parameters (640-dim embeddings),
+suitable when you want multilingual coverage without paying for the 0.6b weights:
+
+```csharp
+using SentenceTransformers.HarrierSmall;
+
+using var encoder = await SentenceEncoder.CreateAsync();
+
+float[][] vectors = await encoder.EncodeAsync(new[]
+{
+    "Good morning",
+    "Buenos días",
+    "おはよう",
+});
+// vectors[0] is a float[640]
 ```
 
 ### Comparing two texts (cosine similarity)
@@ -182,6 +203,35 @@ using var harrier = await SentenceTransformers.Harrier.SentenceEncoder.CreateAsy
 
 You can also pass a custom `Microsoft.ML.OnnxRuntime.SessionOptions` to any constructor / `CreateAsync`
 to tune threading or enable hardware execution providers.
+
+### Choosing a Harrier quantization
+
+The Hugging Face ONNX exports of both Harrier variants ship multiple quantization formats — pick
+the one that fits your CPU / GPU memory budget. URLs for every variant are exposed as constants on
+`SentenceEncoder.Quantizations`:
+
+| Variant     | Constant                                | Harrier 0.6b weights | Harrier Small (270m) weights |
+| ---         | ---                                     | ---:                 | ---:                          |
+| Full (fp32) | `Quantizations.FullModelUrl`            | 2.09 GB (+306 MB)    | 1.11 GB                       |
+| FP16        | `Quantizations.Fp16ModelUrl`            | 1.20 GB              | 553 MB                        |
+| Q4          | `Quantizations.Q4ModelUrl`              | 399 MB               | 205 MB                        |
+| Q4 + FP16   | `Quantizations.Q4Fp16ModelUrl`          | 353 MB               | 172 MB                        |
+| Quantized   | `Quantizations.QuantizedModelUrl` *(default)* | 706 MB         | 344 MB                        |
+
+`Quantized` is the default — it produces float32 output and is the most broadly compatible across
+ONNX Runtime execution providers. `Q4` / `Q4F16` are the smallest on disk; `FP16` keeps the most
+precision per byte; `Full` is the unquantized reference. Each entry has a matching
+`…ModelDataUrl` constant for the external weights file (and the 0.6b `Full` variant additionally
+has `FullModelDataUrl2` because its fp32 weights are split into two files).
+
+```csharp
+using SentenceTransformers.HarrierSmall;
+
+// Use the smallest variant available (Q4F16, ~172 MB):
+using var encoder = await SentenceEncoder.CreateAsync(
+    modelUrl:     SentenceEncoder.Quantizations.Q4Fp16ModelUrl,
+    modelDataUrl: SentenceEncoder.Quantizations.Q4Fp16ModelDataUrl);
+```
 
 ## How it works
 

--- a/SentenceTransformers.Harrier.Medium/SentenceTransformers.Harrier.Medium.csproj
+++ b/SentenceTransformers.Harrier.Medium/SentenceTransformers.Harrier.Medium.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>SentenceTransformers.Harrier.Medium</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,8 +15,8 @@
     <RepositoryUrl>https://github.com/curiosity-ai/sentence-transformers-sharp</RepositoryUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageId>SentenceTransformers.Harrier</PackageId>
-    <Description>The wrapper provides a simple and easy-to-use interface for loading the Harrier (harrier-oss-v1-0.6b) multilingual embeddings model and generating embeddings for input text.</Description>
+    <PackageId>SentenceTransformers.Harrier.Medium</PackageId>
+    <Description>The wrapper provides a simple and easy-to-use interface for loading the Harrier Medium (harrier-oss-v1-0.6b) multilingual embeddings model and generating embeddings for input text.</Description>
     <PackageTags>Harrier, Multilingual, Natural Language Processing, NLP, Machine Learning, ML, Embeddings, Sentence Embeddings,Sentence Transformers, Data Science, Big Data, Artificial Intelligence, AI, NLP Library, Neural Networks, Deep Learning</PackageTags>
   </PropertyGroup>
 

--- a/SentenceTransformers.Harrier.Medium/src/DenseTensorHelpers.cs
+++ b/SentenceTransformers.Harrier.Medium/src/DenseTensorHelpers.cs
@@ -1,7 +1,7 @@
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 
-namespace SentenceTransformers.Harrier;
+namespace SentenceTransformers.Harrier.Medium;
 
 /// <summary>
 /// Helpers for converting ONNX output tensors to float[][] and normalizing embeddings.

--- a/SentenceTransformers.Harrier.Medium/src/HarrierMediumTokenizer.cs
+++ b/SentenceTransformers.Harrier.Medium/src/HarrierMediumTokenizer.cs
@@ -4,21 +4,21 @@ using BERTTokenizers.Base;
 using HFTokenizer = Tokenizers.HuggingFace.Tokenizer.Tokenizer;
 using HFEncoding  = Tokenizers.HuggingFace.Tokenizer.Encoding;
 
-namespace SentenceTransformers.Harrier
+namespace SentenceTransformers.Harrier.Medium
 {
     /// <summary>
     /// Thin wrapper around Tokenizers.HuggingFace for tokenizer.json produced by Hugging Face.
     /// Important: includeTypeIds/includeAttentionMask must be true, otherwise Encoding.TypeIds /
     /// Encoding.AttentionMask will be empty.
     /// </summary>
-    public sealed class HarrierTokenizer : TokenizerBase, IDisposable
+    public sealed class HarrierMediumTokenizer : TokenizerBase, IDisposable
     {
         private readonly HFTokenizer _tokenizer;
 
         // Some tokenizers / FFI wrappers are not guaranteed thread-safe; lock to be safe.
         private readonly object _lock = new();
 
-        public HarrierTokenizer(string tokenizerJsonPath, int maxTokens)
+        public HarrierMediumTokenizer(string tokenizerJsonPath, int maxTokens)
         {
             if (string.IsNullOrWhiteSpace(tokenizerJsonPath))
             {
@@ -102,7 +102,7 @@ namespace SentenceTransformers.Harrier
 
         public override string IdToToken(int id)
         {
-            throw new NotSupportedException("HarrierTokenizer does not expose IdToToken. Use the HuggingFace tokenizer directly if needed.");
+            throw new NotSupportedException("HarrierMediumTokenizer does not expose IdToToken. Use the HuggingFace tokenizer directly if needed.");
         }
 
         public override List<string> TokenizeSimple(string text)
@@ -238,12 +238,12 @@ namespace SentenceTransformers.Harrier
 
         protected override IEnumerable<string> TokenizeSentence(string text)
         {
-            throw new NotSupportedException("HarrierTokenizer uses HuggingFace tokenizers. Use TokenizeRaw/Encode instead.");
+            throw new NotSupportedException("HarrierMediumTokenizer uses HuggingFace tokenizers. Use TokenizeRaw/Encode instead.");
         }
 
         protected override IEnumerable<AlignedString> TokenizeSentenceAligned(string text, List<int> alignment)
         {
-            throw new NotSupportedException("HarrierTokenizer uses HuggingFace tokenizers. Use TokenizeRawAligned/Encode instead.");
+            throw new NotSupportedException("HarrierMediumTokenizer uses HuggingFace tokenizers. Use TokenizeRawAligned/Encode instead.");
         }
 
         public void Dispose()

--- a/SentenceTransformers.Harrier.Medium/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Medium/src/SentenceEncoder.cs
@@ -3,12 +3,12 @@ using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using BERTTokenizers.Base;
 using SentenceTransformers;
-using static SentenceTransformers.Harrier.DenseTensorHelpers;
+using static SentenceTransformers.Harrier.Medium.DenseTensorHelpers;
 
-namespace SentenceTransformers.Harrier
+namespace SentenceTransformers.Harrier.Medium
 {
     /// <summary>
-    /// Sentence encoder for harrier-oss-v1-0.6b ONNX (Microsoft's Harrier multilingual embedding model).
+    /// Sentence encoder for harrier-oss-v1-0.6b ONNX (Microsoft's Harrier Medium multilingual embedding model).
     /// Loads an ONNX model (with optional external data file) from a file path, runs it, and returns
     /// L2-normalized float embeddings (1024-dimensional). The model performs last-token pooling and
     /// L2 normalization internally and exposes a 'sentence_embedding' output.
@@ -100,7 +100,7 @@ namespace SentenceTransformers.Harrier
             string downloadToPath = null,
             CancellationToken cancellationToken = default)
         {
-            var path = downloadToPath ?? Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier", "harrier-model.onnx");
+            var path = downloadToPath ?? Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Medium", "harrier-medium-model.onnx");
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 
             var resolvedModelUrl = modelUrl ?? DefaultModelUrl;
@@ -142,7 +142,7 @@ namespace SentenceTransformers.Harrier
             _outputNames = ResolveOutputNames(_session);
 
             var tokPathToUse = ResolveTokenizerPath(modelOnnxPath);
-            Tokenizer = new HarrierTokenizer(tokPathToUse, MaxChunkLength);
+            Tokenizer = new HarrierMediumTokenizer(tokPathToUse, MaxChunkLength);
         }
 
         /// <summary>
@@ -185,10 +185,10 @@ namespace SentenceTransformers.Harrier
             var bytes = ResourceLoader.GetResource(typeof(SentenceEncoder).Assembly, "tokenizer.json");
             if (bytes is null)
             {
-                throw new FileNotFoundException("tokenizer.json was not found on disk or embedded in the SentenceTransformers.Harrier assembly.");
+                throw new FileNotFoundException("tokenizer.json was not found on disk or embedded in the SentenceTransformers.Harrier.Medium assembly.");
             }
 
-            var cachedPath = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier", "tokenizer.json");
+            var cachedPath = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Medium", "tokenizer.json");
             Directory.CreateDirectory(Path.GetDirectoryName(cachedPath)!);
 
             if (!File.Exists(cachedPath) || new FileInfo(cachedPath).Length != bytes.Length)

--- a/SentenceTransformers.Harrier.Small/SentenceTransformers.Harrier.Small.csproj
+++ b/SentenceTransformers.Harrier.Small/SentenceTransformers.Harrier.Small.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Platforms>AnyCPU</Platforms>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>SentenceTransformers.HarrierSmall</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Curiosity GmbH, Othneil Drew</Authors>
+    <Copyright>(c) Copyright 2026 Curiosity GmbH - all right reserved, Copyright (c) 2021 Othneil Drew (Bert Tokenizers)</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>www.curiosity.ai</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/curiosity-ai/sentence-transformers-sharp</RepositoryUrl>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageId>SentenceTransformers.Harrier.Small</PackageId>
+    <Description>The wrapper provides a simple and easy-to-use interface for loading the Harrier Small (harrier-oss-v1-270m) multilingual embeddings model and generating embeddings for input text.</Description>
+    <PackageTags>Harrier, Multilingual, Natural Language Processing, NLP, Machine Learning, ML, Embeddings, Sentence Embeddings,Sentence Transformers, Data Science, Big Data, Artificial Intelligence, AI, NLP Library, Neural Networks, Deep Learning</PackageTags>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\SentenceTransformers\SentenceTransformers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.24.2" />
+    <PackageReference Include="System.Numerics.Tensors" Version="10.0.3" />
+    <PackageReference Include="Tokenizers.HuggingFace" Version="2.21.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Resources\tokenizer.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <!-- Also embed the tokenizer so NuGet consumers work without copying Resources/tokenizer.json into their output. -->
+    <!-- LogicalName is explicit because RootNamespace ("SentenceTransformers.HarrierSmall") differs
+         from the assembly name ("SentenceTransformers.Harrier.Small") and ResourceLoader looks the
+         resource up by assembly name. -->
+    <EmbeddedResource Include="Resources\tokenizer.json">
+      <LogicalName>SentenceTransformers.Harrier.Small.Resources.tokenizer.json</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+</Project>

--- a/SentenceTransformers.Harrier.Small/SentenceTransformers.Harrier.Small.csproj
+++ b/SentenceTransformers.Harrier.Small/SentenceTransformers.Harrier.Small.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>latest</LangVersion>
-    <RootNamespace>SentenceTransformers.HarrierSmall</RootNamespace>
+    <RootNamespace>SentenceTransformers.Harrier.Small</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,11 +35,6 @@
   <ItemGroup>
     <None Include="Resources\tokenizer.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <!-- Also embed the tokenizer so NuGet consumers work without copying Resources/tokenizer.json into their output. -->
-    <!-- LogicalName is explicit because RootNamespace ("SentenceTransformers.HarrierSmall") differs
-         from the assembly name ("SentenceTransformers.Harrier.Small") and ResourceLoader looks the
-         resource up by assembly name. -->
-    <EmbeddedResource Include="Resources\tokenizer.json">
-      <LogicalName>SentenceTransformers.Harrier.Small.Resources.tokenizer.json</LogicalName>
-    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\tokenizer.json" />
   </ItemGroup>
 </Project>

--- a/SentenceTransformers.Harrier.Small/src/DenseTensorHelpers.cs
+++ b/SentenceTransformers.Harrier.Small/src/DenseTensorHelpers.cs
@@ -1,7 +1,7 @@
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 
-namespace SentenceTransformers.HarrierSmall;
+namespace SentenceTransformers.Harrier.Small;
 
 /// <summary>
 /// Helpers for converting ONNX output tensors to float[][] and normalizing embeddings.

--- a/SentenceTransformers.Harrier.Small/src/DenseTensorHelpers.cs
+++ b/SentenceTransformers.Harrier.Small/src/DenseTensorHelpers.cs
@@ -1,0 +1,76 @@
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace SentenceTransformers.HarrierSmall;
+
+/// <summary>
+/// Helpers for converting ONNX output tensors to float[][] and normalizing embeddings.
+/// </summary>
+public static class DenseTensorHelpers
+{
+    /// <summary>
+    /// Copies a 2D float tensor [batch, embDim] to a jagged array.
+    /// </summary>
+    public static float[][] CopyToJagged(DenseTensor<float> tensor)
+    {
+        var dims = tensor.Dimensions.ToArray();
+        int batch = dims[0];
+        int embDim = dims[1];
+
+        var result = new float[batch][];
+        for (int i = 0; i < batch; i++)
+        {
+            var row = new float[embDim];
+            for (int j = 0; j < embDim; j++)
+            {
+                row[j] = tensor[i, j];
+            }
+            result[i] = row;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Copies a 2D Float16 tensor [batch, embDim] to a jagged float[][] array.
+    /// </summary>
+    public static float[][] CopyToJagged(DenseTensor<Float16> tensor)
+    {
+        var dims = tensor.Dimensions.ToArray();
+        int batch = dims[0];
+        int embDim = dims[1];
+
+        var result = new float[batch][];
+        for (int i = 0; i < batch; i++)
+        {
+            var row = new float[embDim];
+            for (int j = 0; j < embDim; j++)
+            {
+                row[j] = (float)tensor[i, j];
+            }
+            result[i] = row;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Normalizes each row in-place to unit L2 norm.
+    /// </summary>
+    public static void NormalizeRows(float[][] rows, float eps = 1e-12f)
+    {
+        for (int r = 0; r < rows.Length; r++)
+        {
+            var v = rows[r];
+            float sumSq = 0f;
+            for (int i = 0; i < v.Length; i++)
+            {
+                sumSq += v[i] * v[i];
+            }
+            float norm = MathF.Max(MathF.Sqrt(sumSq), eps);
+            float inv = 1f / norm;
+            for (int i = 0; i < v.Length; i++)
+            {
+                v[i] *= inv;
+            }
+        }
+    }
+}

--- a/SentenceTransformers.Harrier.Small/src/HarrierSmallTokenizer.cs
+++ b/SentenceTransformers.Harrier.Small/src/HarrierSmallTokenizer.cs
@@ -4,7 +4,7 @@ using BERTTokenizers.Base;
 using HFTokenizer = Tokenizers.HuggingFace.Tokenizer.Tokenizer;
 using HFEncoding  = Tokenizers.HuggingFace.Tokenizer.Encoding;
 
-namespace SentenceTransformers.HarrierSmall
+namespace SentenceTransformers.Harrier.Small
 {
     /// <summary>
     /// Thin wrapper around Tokenizers.HuggingFace for tokenizer.json produced by Hugging Face,

--- a/SentenceTransformers.Harrier.Small/src/HarrierSmallTokenizer.cs
+++ b/SentenceTransformers.Harrier.Small/src/HarrierSmallTokenizer.cs
@@ -1,0 +1,294 @@
+using BERTTokenizers.Base;
+
+// Alias to avoid name collision with our own types
+using HFTokenizer = Tokenizers.HuggingFace.Tokenizer.Tokenizer;
+using HFEncoding  = Tokenizers.HuggingFace.Tokenizer.Encoding;
+
+namespace SentenceTransformers.HarrierSmall
+{
+    /// <summary>
+    /// Thin wrapper around Tokenizers.HuggingFace for tokenizer.json produced by Hugging Face,
+    /// for the Harrier Small (harrier-oss-v1-270m) model. The model is Gemma3-based, so its
+    /// tokenizer / vocabulary differ from the larger 0.6b Harrier variant.
+    /// includeTypeIds/includeAttentionMask must be true, otherwise Encoding.TypeIds /
+    /// Encoding.AttentionMask will be empty.
+    /// </summary>
+    public sealed class HarrierSmallTokenizer : TokenizerBase, IDisposable
+    {
+        private readonly HFTokenizer _tokenizer;
+
+        // Some tokenizers / FFI wrappers are not guaranteed thread-safe; lock to be safe.
+        private readonly object _lock = new();
+
+        public HarrierSmallTokenizer(string tokenizerJsonPath, int maxTokens)
+        {
+            if (string.IsNullOrWhiteSpace(tokenizerJsonPath))
+            {
+                throw new ArgumentException("tokenizerJsonPath is null/empty", nameof(tokenizerJsonPath));
+            }
+
+            if (!File.Exists(tokenizerJsonPath))
+            {
+                throw new FileNotFoundException("tokenizer.json not found", tokenizerJsonPath);
+            }
+
+            _tokenizer = HFTokenizer.FromFile(tokenizerJsonPath);
+            SetMaxTokens(maxTokens);
+            ApproxCharToTokenRatio = 4; // Byte-level BPE tends to be denser than WordPiece
+        }
+
+        public new void SetMaxTokens(int maxTokens)
+        {
+            if (maxTokens <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxTokens));
+            }
+            base.SetMaxTokens(maxTokens);
+        }
+
+        /// <summary>
+        /// Returns per-sentence token arrays (variable length).
+        /// Padding to a uniform length is done in the encoder.
+        /// </summary>
+        public List<(long[] InputIds, long[] TokenTypeIds, long[] AttentionMask)> Encode(string[] sentences, bool addSpecialTokens = true)
+        {
+            if (sentences is null)
+            {
+                throw new ArgumentNullException(nameof(sentences));
+            }
+
+            var result = new List<(long[], long[], long[])>(sentences.Length);
+
+            foreach (var sentence in sentences)
+            {
+                var text = sentence ?? string.Empty;
+
+                var enc = EncodeOne(text, addSpecialTokens, includeTypeIds: true, includeTokens: false, includeOffsets: false, includeAttentionMask: true);
+
+                var ids = enc.Ids.Select(x => (long)x).ToArray();
+
+                // Some tokenizers may return empty TypeIds (model may not use them); keep lengths consistent.
+                long[] typeIds = enc.TypeIds.Count == ids.Length
+                    ? enc.TypeIds.Select(x => (long)x).ToArray()
+                    : new long[ids.Length];
+
+                // AttentionMask should be present when includeAttentionMask=true, but be defensive.
+                long[] attn = enc.AttentionMask.Count == ids.Length
+                    ? enc.AttentionMask.Select(x => (long)x).ToArray()
+                    : Enumerable.Repeat(1L, ids.Length).ToArray();
+
+                // Optional truncation (keep arrays aligned)
+                if (ids.Length > MaxTokens)
+                {
+                    ids = ids[..MaxTokens];
+                    if (typeIds.Length > MaxTokens)
+                    {
+                        typeIds = typeIds[..MaxTokens];
+                    }
+                    if (attn.Length > MaxTokens)
+                    {
+                        attn = attn[..MaxTokens];
+                    }
+                }
+
+                result.Add((ids, typeIds, attn));
+            }
+
+            return result;
+        }
+
+        public override List<(long[] InputIds, long[] TokenTypeIds, long[] AttentionMask)> Encode(params string[] texts)
+        {
+            return Encode(texts, addSpecialTokens: true);
+        }
+
+        public override string IdToToken(int id)
+        {
+            throw new NotSupportedException("HarrierSmallTokenizer does not expose IdToToken. Use the HuggingFace tokenizer directly if needed.");
+        }
+
+        public override List<string> TokenizeSimple(string text)
+        {
+            var enc = EncodeOne(text ?? string.Empty, addSpecialTokens: false, includeTypeIds: false, includeTokens: true, includeOffsets: false, includeAttentionMask: false);
+            return enc.Tokens.ToList();
+        }
+
+        public override List<(string Token, int VocabularyIndex, long SegmentIndex)[]> Tokenize(int maxTokens, params string[] texts)
+        {
+            if (texts is null)
+            {
+                throw new ArgumentNullException(nameof(texts));
+            }
+
+            var result = new List<(string Token, int VocabularyIndex, long SegmentIndex)[]>(texts.Length);
+
+            foreach (var text in texts)
+            {
+                var enc = EncodeOne(text ?? string.Empty, addSpecialTokens: true, includeTypeIds: true, includeTokens: true, includeOffsets: false, includeAttentionMask: false);
+
+                int take = Math.Min(maxTokens, enc.Ids.Count);
+                var row = new (string Token, int VocabularyIndex, long SegmentIndex)[take];
+
+                for (int i = 0; i < take; i++)
+                {
+                    row[i] = (enc.Tokens[i], (int)enc.Ids[i], enc.TypeIds.Count > i ? enc.TypeIds[i] : 0L);
+                }
+
+                result.Add(row);
+            }
+
+            return result;
+        }
+
+        public override List<TokenizedToken> TokenizeRaw(ReadOnlySpan<char> text)
+        {
+            var textString = text.ToString();
+            if (textString.Length == 0)
+            {
+                return new List<TokenizedToken>();
+            }
+
+            var enc = EncodeOne(textString, addSpecialTokens: false, includeTypeIds: false, includeTokens: true, includeOffsets: true, includeAttentionMask: false);
+
+            var tokens = enc.Tokens;
+            var offsets = enc.Offsets;
+
+            var result = new List<TokenizedToken>(tokens.Count);
+            int len = textString.Length;
+
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                var offset = offsets[i];
+                int start = ClampOffset(Convert.ToInt64(offset.Start), len);
+                int end = ClampOffset(Convert.ToInt64(offset.End), len);
+
+                if (end <= start)
+                {
+                    continue; // skip special tokens / empty spans
+                }
+
+                var original = textString.Substring(start, end - start);
+                result.Add(new TokenizedToken(tokens[i], original));
+            }
+
+            return result;
+        }
+
+        public override List<TokenizedTokenAligned> TokenizeRawAligned(ReadOnlySpan<char> text)
+        {
+            var textString = text.ToString();
+            if (textString.Length == 0)
+            {
+                return new List<TokenizedTokenAligned>();
+            }
+
+            var enc = EncodeOne(textString, addSpecialTokens: false, includeTypeIds: false, includeTokens: true, includeOffsets: true, includeAttentionMask: false);
+
+            var tokens = enc.Tokens;
+            var offsets = enc.Offsets;
+
+            var result = new List<TokenizedTokenAligned>(tokens.Count);
+            int len = textString.Length;
+
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                var offset = offsets[i];
+                int start = ClampOffset(Convert.ToInt64(offset.Start), len);
+                int end = ClampOffset(Convert.ToInt64(offset.End), len);
+
+                if (end <= start)
+                {
+                    continue; // skip special tokens / empty spans
+                }
+
+                var original = textString.Substring(start, end - start);
+                result.Add(new TokenizedTokenAligned(tokens[i], original, start, end));
+            }
+
+            return result;
+        }
+
+        public override List<string> Untokenize(List<TokenizedToken> tokens)
+        {
+            if (tokens is null || tokens.Count == 0)
+            {
+                return new List<string>();
+            }
+            var text = string.Concat(tokens.Select(t => t.Original ?? string.Empty));
+            return string.IsNullOrEmpty(text) ? new List<string>() : new List<string> { text };
+        }
+
+        public override List<AlignedString> Untokenize(List<TokenizedTokenAligned> tokens, string originalText)
+        {
+            if (tokens is null || tokens.Count == 0)
+            {
+                return new List<AlignedString>();
+            }
+
+            var text = string.Concat(tokens.Select(t => t.Original ?? string.Empty));
+            if (string.IsNullOrEmpty(text))
+            {
+                return new List<AlignedString>();
+            }
+
+            var start = tokens[0].Start;
+            var lastStart = tokens[^1].Start;
+            var end = tokens[^1].ApproximateEnd;
+
+            return new List<AlignedString> { new AlignedString(text, start, lastStart, end, originalText) };
+        }
+
+        protected override IEnumerable<string> TokenizeSentence(string text)
+        {
+            throw new NotSupportedException("HarrierSmallTokenizer uses HuggingFace tokenizers. Use TokenizeRaw/Encode instead.");
+        }
+
+        protected override IEnumerable<AlignedString> TokenizeSentenceAligned(string text, List<int> alignment)
+        {
+            throw new NotSupportedException("HarrierSmallTokenizer uses HuggingFace tokenizers. Use TokenizeRawAligned/Encode instead.");
+        }
+
+        public void Dispose()
+        {
+            try { _tokenizer?.Dispose(); } catch { /* swallow */ }
+        }
+
+        private HFEncoding EncodeOne(
+            string text,
+            bool addSpecialTokens,
+            bool includeTypeIds,
+            bool includeTokens,
+            bool includeOffsets,
+            bool includeAttentionMask)
+        {
+            lock (_lock)
+            {
+                return _tokenizer
+                    .Encode(
+                        text,
+                        addSpecialTokens,
+                        includeTypeIds: includeTypeIds,
+                        includeTokens: includeTokens,
+                        includeWords: false,
+                        includeOffsets: includeOffsets,
+                        includeSpecialTokensMask: false,
+                        includeAttentionMask: includeAttentionMask,
+                        includeOverflowing: false)
+                    .First();
+            }
+        }
+
+        private static int ClampOffset(long value, int length)
+        {
+            if (value < 0)
+            {
+                return 0;
+            }
+            if (value > length)
+            {
+                return length;
+            }
+            return (int)value;
+        }
+    }
+}

--- a/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
@@ -1,0 +1,476 @@
+using System.Net.Http.Headers;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using BERTTokenizers.Base;
+using SentenceTransformers;
+using static SentenceTransformers.HarrierSmall.DenseTensorHelpers;
+
+namespace SentenceTransformers.HarrierSmall
+{
+    /// <summary>
+    /// Sentence encoder for harrier-oss-v1-270m ONNX (Microsoft's small Harrier multilingual embedding model).
+    /// Loads an ONNX model (with optional external data file) from a file path, runs it, and returns
+    /// L2-normalized float embeddings (640-dimensional). The model performs last-token pooling and
+    /// L2 normalization internally and exposes a 'sentence_embedding' output.
+    /// Use <see cref="CreateAsync"/> to download then load the model to a path.
+    /// Tokenizer is loaded from Resources/tokenizer.json (under the application base directory).
+    /// </summary>
+    public sealed class SentenceEncoder : IDisposable, ISentenceEncoder
+    {
+        /// <summary>
+        /// Default URL used to download the ONNX model when no path is provided.
+        /// Points to the standard quantized variant (~344 MB external data) which produces
+        /// float32 output and is the most broadly compatible with onnxruntime CPU/GPU providers.
+        /// </summary>
+        public const string DefaultModelUrl = Quantizations.QuantizedModelUrl;
+
+        /// <summary>
+        /// Default URL for the external ONNX data file that accompanies <see cref="DefaultModelUrl"/>.
+        /// Hugging Face splits Harrier ONNX models into a small graph file plus a separate weights file.
+        /// </summary>
+        public const string DefaultModelDataUrl = Quantizations.QuantizedModelDataUrl;
+
+        /// <summary>
+        /// Download URLs for the Harrier Small (270m) ONNX model variants published by
+        /// onnx-community/harrier-oss-v1-270m-ONNX on Hugging Face. Each variant exposes a small
+        /// <c>.onnx</c> graph file paired with one <c>.onnx_data</c> weight file. When downloading
+        /// a graph file, you must also download the matching <c>.onnx_data</c> file to the same
+        /// folder under its exact upstream filename - ONNX Runtime resolves the external weights
+        /// by the name referenced inside the graph.
+        /// </summary>
+        public static class Quantizations
+        {
+            private const string BaseUrl = "https://huggingface.co/onnx-community/harrier-oss-v1-270m-ONNX/resolve/main/onnx/";
+
+            /// <summary>Full-precision (fp32) graph (~1.11 GB external weights).</summary>
+            public const string FullModelUrl              = BaseUrl + "model.onnx";
+            /// <summary>External weights for <see cref="FullModelUrl"/>.</summary>
+            public const string FullModelDataUrl          = BaseUrl + "model.onnx_data";
+
+            /// <summary>FP16 graph (~553 MB external weights).</summary>
+            public const string Fp16ModelUrl              = BaseUrl + "model_fp16.onnx";
+            /// <summary>External weights for <see cref="Fp16ModelUrl"/>.</summary>
+            public const string Fp16ModelDataUrl          = BaseUrl + "model_fp16.onnx_data";
+
+            /// <summary>4-bit quantized graph (~205 MB external weights).</summary>
+            public const string Q4ModelUrl                = BaseUrl + "model_q4.onnx";
+            /// <summary>External weights for <see cref="Q4ModelUrl"/>.</summary>
+            public const string Q4ModelDataUrl            = BaseUrl + "model_q4.onnx_data";
+
+            /// <summary>4-bit-with-FP16-residual graph (~172 MB external weights). Smallest variant.</summary>
+            public const string Q4Fp16ModelUrl            = BaseUrl + "model_q4f16.onnx";
+            /// <summary>External weights for <see cref="Q4Fp16ModelUrl"/>.</summary>
+            public const string Q4Fp16ModelDataUrl        = BaseUrl + "model_q4f16.onnx_data";
+
+            /// <summary>Standard quantized graph (~344 MB external weights, fp32 output). The default variant.</summary>
+            public const string QuantizedModelUrl         = BaseUrl + "model_quantized.onnx";
+            /// <summary>External weights for <see cref="QuantizedModelUrl"/>.</summary>
+            public const string QuantizedModelDataUrl     = BaseUrl + "model_quantized.onnx_data";
+        }
+
+        private static readonly SemaphoreSlim _oneDownloadAtATime = new(1, 1);
+        private static readonly HttpClient _downloadClient = new() { Timeout = TimeSpan.FromDays(1) };
+
+        private readonly SessionOptions _sessionOptions;
+        private readonly InferenceSession _session;
+        private readonly string[] _outputNames;
+
+        public TokenizerBase Tokenizer { get; }
+
+        public static int GetMaxChunkLength() => 32768;
+        public int MaxChunkLength => GetMaxChunkLength();
+
+        /// <summary>Returns true if a model download is currently in progress.</summary>
+        public static bool IsDownloading() => _oneDownloadAtATime.CurrentCount < 1;
+
+        /// <summary>
+        /// Downloads the model (and its external data file, when applicable) to <paramref name="downloadToPath"/>
+        /// (or a temp path if null), then creates an encoder from that path. Tokenizer is loaded from
+        /// Resources/tokenizer.json.
+        /// </summary>
+        /// <param name="modelUrl">URL for the .onnx graph file. Defaults to <see cref="DefaultModelUrl"/>.</param>
+        /// <param name="modelDataUrl">URL for the accompanying .onnx_data weights file. Pass null to skip.
+        /// Defaults to <see cref="DefaultModelDataUrl"/> when <paramref name="modelUrl"/> is also null.</param>
+        public static async Task<SentenceEncoder> CreateAsync(
+            SessionOptions sessionOptions = null,
+            string modelUrl = null,
+            string modelDataUrl = null,
+            string downloadToPath = null,
+            CancellationToken cancellationToken = default)
+        {
+            var path = downloadToPath ?? Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small", "harrier-small-model.onnx");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+            var resolvedModelUrl = modelUrl ?? DefaultModelUrl;
+            // If user supplied modelUrl but no data url, do not auto-download data file.
+            // If user left both null, use the default pair.
+            var resolvedDataUrl = modelDataUrl ?? (modelUrl is null ? DefaultModelDataUrl : null);
+
+            await DownloadModelAsync(resolvedModelUrl, path, cancellationToken);
+            if (!string.IsNullOrEmpty(resolvedDataUrl))
+            {
+                // ONNX runtime expects the external data file to live next to the .onnx file
+                // with the exact name referenced in the model's external_data entry.
+                var dataFileName = Path.GetFileName(new Uri(resolvedDataUrl).LocalPath);
+                var dataPath = Path.Combine(Path.GetDirectoryName(path)!, dataFileName);
+                await DownloadModelAsync(resolvedDataUrl, dataPath, cancellationToken);
+            }
+            return new SentenceEncoder(sessionOptions, path);
+        }
+
+        // Toggle if you want to match "no normalization" behavior. The model already L2-normalizes
+        // its output; this flag re-normalizes float[][] after copy as a safety net.
+        public bool Normalize { get; set; } = true;
+
+        /// <summary>Creates an encoder from an existing ONNX model file at <paramref name="modelOnnxPath"/>.</summary>
+        /// <param name="modelOnnxPath">Path to the ONNX model file. If the model uses external data,
+        /// the data file must live in the same directory under the name referenced by the graph.</param>
+        public SentenceEncoder(SessionOptions sessionOptions = null, string modelOnnxPath = null)
+        {
+            if (string.IsNullOrWhiteSpace(modelOnnxPath))
+            {
+                throw new ArgumentException("Model path is required.", nameof(modelOnnxPath));
+            }
+            _sessionOptions = sessionOptions ?? new SessionOptions();
+            _sessionOptions.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL;
+
+            _session = new InferenceSession(modelOnnxPath, _sessionOptions);
+            _outputNames = ResolveOutputNames(_session);
+
+            var tokPathToUse = ResolveTokenizerPath(modelOnnxPath);
+            Tokenizer = new HarrierSmallTokenizer(tokPathToUse, MaxChunkLength);
+        }
+
+        /// <summary>
+        /// Picks the sentence-embedding output. Harrier exports an output named
+        /// <c>sentence_embedding</c>; if absent, fall back to the first output.
+        /// </summary>
+        private static string[] ResolveOutputNames(InferenceSession session)
+        {
+            var keys = session.OutputMetadata.Keys.ToArray();
+            var preferred = keys.FirstOrDefault(k => string.Equals(k, "sentence_embedding", StringComparison.Ordinal))
+                         ?? keys.FirstOrDefault(k => k.Contains("sentence_embedding", StringComparison.OrdinalIgnoreCase))
+                         ?? keys.FirstOrDefault();
+            if (preferred is null)
+            {
+                throw new InvalidOperationException("ONNX model has no outputs.");
+            }
+            return new[] { preferred };
+        }
+
+        /// <summary>
+        /// Resolves the tokenizer.json path. Prefers <c>Resources/tokenizer.json</c> next to the application
+        /// (under the app base directory); when that is missing - e.g. when this library is consumed as a NuGet
+        /// package and the consumer did not copy the file to its output - it falls back to the copy embedded in
+        /// this assembly, extracting it once to a temp location.
+        /// </summary>
+        private static string ResolveTokenizerPath(string modelOnnxPath)
+        {
+            var resourcesPath = Path.Combine(AppContext.BaseDirectory, "Resources", "tokenizer.json");
+            if (File.Exists(resourcesPath))
+            {
+                return resourcesPath;
+            }
+
+            return ExtractEmbeddedTokenizer();
+        }
+
+        /// <summary>Writes the embedded tokenizer.json to a stable temp path (once) and returns it.</summary>
+        private static string ExtractEmbeddedTokenizer()
+        {
+            var bytes = ResourceLoader.GetResource(typeof(SentenceEncoder).Assembly, "tokenizer.json");
+            if (bytes is null)
+            {
+                throw new FileNotFoundException("tokenizer.json was not found on disk or embedded in the SentenceTransformers.Harrier.Small assembly.");
+            }
+
+            var cachedPath = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small", "tokenizer.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(cachedPath)!);
+
+            if (!File.Exists(cachedPath) || new FileInfo(cachedPath).Length != bytes.Length)
+            {
+                File.WriteAllBytes(cachedPath, bytes);
+            }
+
+            return cachedPath;
+        }
+
+        public void Dispose()
+        {
+            _session?.Dispose();
+            _sessionOptions?.Dispose();
+        }
+
+        public async Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default)
+        {
+            if (sentences is null || sentences.Length == 0)
+            {
+                return Array.Empty<float[]>();
+            }
+
+            var encoded = Tokenizer.Encode(sentences);
+            if (encoded.Count == 0)
+            {
+                return Array.Empty<float[]>();
+            }
+
+            int batch = encoded.Count;
+            int maxLen = encoded.Max(e => e.InputIds.Length);
+            if (maxLen <= 0)
+            {
+                return Array.Empty<float[]>();
+            }
+
+            var inputs = BuildModelInputs(encoded, batch, maxLen);
+
+            using var runOptions = new RunOptions();
+            using var registration = cancellationToken.Register(() => runOptions.Terminate = true);
+
+            try
+            {
+                using var outputs = _session.Run(inputs, _outputNames, runOptions);
+                var raw = outputs.First().Value;
+
+                float[][] result = raw switch
+                {
+                    DenseTensor<float> floatTensor => CopyToJagged(floatTensor),
+                    DenseTensor<Float16> halfTensor => CopyToJagged(halfTensor),
+                    _ => throw new InvalidOperationException(
+                        $"Unexpected ONNX output type: {raw?.GetType().FullName ?? "null"}")
+                };
+
+                if (Normalize)
+                {
+                    NormalizeRows(result);
+                }
+                return result;
+            }
+            catch (OnnxRuntimeException e)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException("Encoding was cancelled", e, cancellationToken);
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Tokenizes <paramref name="text"/> and merges tokens into chunks of at most
+        /// <paramref name="chunkLength"/> tokens with <paramref name="chunkOverlap"/> tokens of
+        /// overlap. Each chunk's text is reconstructed by slicing the source between the first and
+        /// last token's offsets returned by the Hugging Face tokenizer, which preserves the exact
+        /// original whitespace and any injected markers. This is the BPE-appropriate replacement
+        /// for the WordPiece-oriented <see cref="ISentenceEncoder.ChunkTokens"/> default.
+        /// </summary>
+        /// <param name="text">Source text to chunk.</param>
+        /// <param name="chunkLength">Maximum tokens per chunk.</param>
+        /// <param name="chunkOverlap">Tokens of overlap between consecutive chunks.</param>
+        /// <param name="maxChunks">Hard cap on the number of chunks returned.</param>
+        /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+        public List<string> ChunkTokens(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+            => BPEChunkAndEncodeHelpers.ChunkTokens(Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkTokens"/>: each chunk carries offsets back into
+        /// <paramref name="text"/>.
+        /// </summary>
+        /// <inheritdoc cref="ChunkTokens"/>
+        public List<AlignedString> ChunkTokensAligned(string text, int chunkLength = 500, int chunkOverlap = 100, int maxChunks = int.MaxValue, Action<float> reportProgress = null)
+            => BPEChunkAndEncodeHelpers.ChunkTokensAligned(Tokenizer, text, chunkLength, chunkOverlap, maxChunks, reportProgress);
+
+        /// <summary>
+        /// Splits <paramref name="text"/> into BPE-token-bounded chunks and encodes each chunk to
+        /// an embedding. Uses offset-based chunk reconstruction (see <see cref="ChunkTokens"/>).
+        /// </summary>
+        /// <param name="text">Source text. May be longer than <see cref="MaxChunkLength"/>.</param>
+        /// <param name="chunkLength">Maximum tokens per chunk. Values <c>&lt;= 0</c> or above <see cref="MaxChunkLength"/> are clamped to <see cref="MaxChunkLength"/>.</param>
+        /// <param name="chunkOverlap">Tokens of overlap between consecutive chunks. Out-of-range values default to <c>chunkLength / 5</c>.</param>
+        /// <param name="sequentially">When true, encode chunks one-by-one; when false, encode in a single batched call.</param>
+        /// <param name="maxChunks">Hard cap on chunks produced.</param>
+        /// <param name="keepResultsOnCancellation">When true and cancelled, returns the chunks already encoded.</param>
+        /// <param name="reportProgress">Optional progress callback receiving values in <c>[0,1]</c>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public Task<EncodedChunk[]> ChunkAndEncodeAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeAsync(this, text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkAndEncodeAsync"/>: each result also carries offsets
+        /// back into <paramref name="text"/>.
+        /// </summary>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<EncodedChunkAligned[]> ChunkAndEncodeAlignedAsync(string text, int chunkLength = -1, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeAlignedAsync(this, text, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Chunks <paramref name="text"/> using BPE offsets, then for each chunk runs
+        /// <paramref name="stripTags"/> to remove injected markers and recover a tag before
+        /// encoding the cleaned text. The chunker treats markers as ordinary tokens.
+        /// </summary>
+        /// <param name="text">Source text with injected markers.</param>
+        /// <param name="stripTags">Callback that strips markers and produces a <see cref="TaggedChunk"/> (cleaned text + tag).</param>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<TaggedEncodedChunk[]> ChunkAndEncodeTaggedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAsync(this, text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        /// <summary>
+        /// Aligned variant of <see cref="ChunkAndEncodeTaggedAsync"/>: each result carries offsets
+        /// into <paramref name="text"/> alongside the cleaned text, tag, and embedding.
+        /// </summary>
+        /// <param name="text">Source text with injected markers.</param>
+        /// <param name="stripTags">Callback that strips markers from the original chunk substring and produces a <see cref="TaggedChunk"/>.</param>
+        /// <inheritdoc cref="ChunkAndEncodeAsync"/>
+        public Task<TaggedEncodedChunkAligned[]> ChunkAndEncodeTaggedAlignedAsync(string text, Func<string, TaggedChunk> stripTags, int chunkLength = 500, int chunkOverlap = 100, bool sequentially = true, int maxChunks = int.MaxValue, bool keepResultsOnCancellation = false, Action<float> reportProgress = null, CancellationToken cancellationToken = default)
+            => BPEChunkAndEncodeHelpers.ChunkAndEncodeTaggedAlignedAsync(this, text, stripTags, chunkLength, chunkOverlap, sequentially, maxChunks, keepResultsOnCancellation, reportProgress, cancellationToken);
+
+        private List<NamedOnnxValue> BuildModelInputs(
+            List<(long[] InputIds, long[] TokenTypeIds, long[] AttentionMask)> encoded,
+            int batch,
+            int maxLen)
+        {
+            // harrier-oss-v1-270m is a Gemma3-based model with pad_token_id = 0. Pre-fill input_ids
+            // with the pad id so right-padding tokens are recognized by the model; attention_mask
+            // remains 0 there.
+            const long PadTokenId = 0L;
+            var inputIds = new long[batch * maxLen];
+            // Array.Fill is unnecessary when PadTokenId is 0, but keep the pattern explicit so the
+            // pad id is obvious and the code stays parallel to the 0.6b variant.
+            Array.Fill(inputIds, PadTokenId);
+            var attMask = new long[batch * maxLen];
+            var typeIds = new long[batch * maxLen];
+
+            for (int b = 0; b < batch; b++)
+            {
+                var (ids, tts, am) = encoded[b];
+                int offset = b * maxLen;
+                Array.Copy(ids, 0, inputIds, offset, ids.Length);
+                Array.Copy(am, 0, attMask, offset, am.Length);
+                if (tts is { Length: > 0 })
+                {
+                    Array.Copy(tts, 0, typeIds, offset, Math.Min(tts.Length, maxLen));
+                }
+            }
+
+            var shape = new[] { batch, maxLen };
+            string inputIdsName = FindInputName(_session, "input_ids");
+            string attMaskName = FindInputName(_session, "attention_mask");
+            string typeIdsName = _session.InputMetadata.Keys.FirstOrDefault(k => k == "token_type_ids");
+
+            var inputs = new List<NamedOnnxValue>(3)
+            {
+                NamedOnnxValue.CreateFromTensor(inputIdsName, new DenseTensor<long>(inputIds, shape)),
+                NamedOnnxValue.CreateFromTensor(attMaskName, new DenseTensor<long>(attMask, shape)),
+            };
+            if (typeIdsName is not null)
+            {
+                inputs.Add(NamedOnnxValue.CreateFromTensor(typeIdsName, new DenseTensor<long>(typeIds, shape)));
+            }
+            return inputs;
+        }
+
+        private static string FindInputName(InferenceSession session, string preferred)
+        {
+            if (session.InputMetadata.ContainsKey(preferred))
+            {
+                return preferred;
+            }
+
+            // Basic fallback heuristics
+            var match = session.InputMetadata.Keys.FirstOrDefault(k => k.Contains(preferred, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                return match;
+            }
+
+            throw new InvalidOperationException(
+                $"Model input '{preferred}' not found. Available inputs: {string.Join(", ", session.InputMetadata.Keys)}");
+        }
+
+        /// <summary>
+        /// Downloads a file from <paramref name="modelUrl"/> to <paramref name="localPath"/>.
+        /// Only one download runs at a time. On failure, any partial file at <paramref name="localPath"/> is deleted.
+        /// Re-used for both the .onnx graph and its accompanying .onnx_data file.
+        /// </summary>
+        public static async Task DownloadModelAsync(string modelUrl, string localPath, CancellationToken cancellationToken = default)
+        {
+            if (File.Exists(localPath)) return;
+
+            if (!Uri.TryCreate(modelUrl, UriKind.Absolute, out var uri) || uri.Scheme is not ("https" or "http"))
+            {
+                throw new InvalidOperationException($"Invalid model URL: '{modelUrl}'. Use a valid http(s) URL.");
+            }
+
+            if (string.IsNullOrWhiteSpace(localPath))
+            {
+                throw new ArgumentException("Local path must be non-empty.", nameof(localPath));
+            }
+
+
+            await _oneDownloadAtATime.WaitAsync(cancellationToken);
+            try
+            {
+                var buffer = new byte[2 << 18]; // 512kb
+                var response = await _downloadClient.GetAsync(modelUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                try
+                {
+                    response.EnsureSuccessStatusCode();
+                    var supportsRange = response.Headers.AcceptRanges.Contains("bytes");
+
+                    await using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, buffer.Length, true);
+                    var totalBytesRead = 0L;
+                    var finished = false;
+
+                    while (!finished)
+                    {
+                        try
+                        {
+                            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                            int bytesRead;
+                            while ((bytesRead = await contentStream.ReadAsync(buffer, cancellationToken)) > 0)
+                            {
+                                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                                totalBytesRead += bytesRead;
+                            }
+                            finished = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            if (ex is TaskCanceledException)
+                            {
+                                try { File.Delete(localPath); } catch { /* ignore */ }
+                                throw new OperationCanceledException("Model download was cancelled.", ex, cancellationToken);
+                            }
+                            await Task.Delay(5000, cancellationToken);
+                            var newRequest = new HttpRequestMessage(HttpMethod.Get, modelUrl);
+                            if (supportsRange && totalBytesRead > 0)
+                            {
+                                newRequest.Headers.Range = new RangeHeaderValue(totalBytesRead, null);
+                            }
+                            else
+                            {
+                                totalBytesRead = 0;
+                                fileStream.Position = 0;
+                            }
+                            response.Dispose();
+                            response = await _downloadClient.SendAsync(newRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                            response.EnsureSuccessStatusCode();
+                        }
+                    }
+                }
+                finally
+                {
+                    response?.Dispose();
+                }
+            }
+            catch (Exception)
+            {
+                File.Delete(localPath);
+                throw;
+            }
+            finally
+            {
+                _oneDownloadAtATime.Release();
+            }
+        }
+    }
+}

--- a/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
@@ -3,9 +3,9 @@ using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using BERTTokenizers.Base;
 using SentenceTransformers;
-using static SentenceTransformers.HarrierSmall.DenseTensorHelpers;
+using static SentenceTransformers.Harrier.Small.DenseTensorHelpers;
 
-namespace SentenceTransformers.HarrierSmall
+namespace SentenceTransformers.Harrier.Small
 {
     /// <summary>
     /// Sentence encoder for harrier-oss-v1-270m ONNX (Microsoft's small Harrier multilingual embedding model).

--- a/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
@@ -40,7 +40,7 @@ namespace SentenceTransformers.HarrierSmall
         /// </summary>
         public static class Quantizations
         {
-            private const string BaseUrl = "https://huggingface.co/onnx-community/harrier-oss-v1-270m-ONNX/resolve/main/onnx/";
+            private const string BaseUrl = "https://models.curiosity.ai/harrier-oss-v1-270m-onnx/";
 
             /// <summary>Full-precision (fp32) graph (~1.11 GB external weights).</summary>
             public const string FullModelUrl              = BaseUrl + "model.onnx";

--- a/SentenceTransformers.Harrier/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier/src/SentenceEncoder.cs
@@ -30,6 +30,46 @@ namespace SentenceTransformers.Harrier
         /// </summary>
         public const string DefaultModelDataUrl = "https://models.curiosity.ai/harrier-model_quantized.onnx_data";
 
+        /// <summary>
+        /// Download URLs for the Harrier 0.6b ONNX model variants published by
+        /// onnx-community/harrier-oss-v1-0.6b-ONNX on Hugging Face. Each variant exposes a small
+        /// <c>.onnx</c> graph file paired with one or more <c>.onnx_data</c> weight files. When
+        /// downloading a graph file, you must also download every <c>…_data*</c> file from the same
+        /// row to the same folder under its exact upstream filename - ONNX Runtime resolves the
+        /// external weights by the name referenced inside the graph.
+        /// </summary>
+        public static class Quantizations
+        {
+            private const string BaseUrl = "https://huggingface.co/onnx-community/harrier-oss-v1-0.6b-ONNX/resolve/main/onnx/";
+
+            /// <summary>Full-precision (fp32) graph (~2.09 GB external + ~306 MB second weights file).</summary>
+            public const string FullModelUrl              = BaseUrl + "model.onnx";
+            /// <summary>First external weights file for <see cref="FullModelUrl"/>.</summary>
+            public const string FullModelDataUrl          = BaseUrl + "model.onnx_data";
+            /// <summary>Second external weights file for <see cref="FullModelUrl"/> (fp32 weights are split across two files).</summary>
+            public const string FullModelDataUrl2         = BaseUrl + "model.onnx_data_1";
+
+            /// <summary>FP16 graph (~1.2 GB external weights).</summary>
+            public const string Fp16ModelUrl              = BaseUrl + "model_fp16.onnx";
+            /// <summary>External weights for <see cref="Fp16ModelUrl"/>.</summary>
+            public const string Fp16ModelDataUrl          = BaseUrl + "model_fp16.onnx_data";
+
+            /// <summary>4-bit quantized graph (~399 MB external weights).</summary>
+            public const string Q4ModelUrl                = BaseUrl + "model_q4.onnx";
+            /// <summary>External weights for <see cref="Q4ModelUrl"/>.</summary>
+            public const string Q4ModelDataUrl            = BaseUrl + "model_q4.onnx_data";
+
+            /// <summary>4-bit-with-FP16-residual graph (~353 MB external weights).</summary>
+            public const string Q4Fp16ModelUrl            = BaseUrl + "model_q4f16.onnx";
+            /// <summary>External weights for <see cref="Q4Fp16ModelUrl"/>.</summary>
+            public const string Q4Fp16ModelDataUrl        = BaseUrl + "model_q4f16.onnx_data";
+
+            /// <summary>Standard quantized graph (~706 MB external weights, fp32 output). The default variant.</summary>
+            public const string QuantizedModelUrl         = BaseUrl + "model_quantized.onnx";
+            /// <summary>External weights for <see cref="QuantizedModelUrl"/>.</summary>
+            public const string QuantizedModelDataUrl     = BaseUrl + "model_quantized.onnx_data";
+        }
+
         private static readonly SemaphoreSlim _oneDownloadAtATime = new(1, 1);
         private static readonly HttpClient _downloadClient = new() { Timeout = TimeSpan.FromDays(1) };
 

--- a/SentenceTransformers.Harrier/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier/src/SentenceEncoder.cs
@@ -22,13 +22,13 @@ namespace SentenceTransformers.Harrier
         /// Points to the standard quantized variant (~706 MB external data) which produces
         /// float32 output and is the most broadly compatible with onnxruntime CPU/GPU providers.
         /// </summary>
-        public const string DefaultModelUrl = "https://models.curiosity.ai/harrier-model_quantized.onnx";
+        public const string DefaultModelUrl = Quantizations.QuantizedModelUrl;
 
         /// <summary>
         /// Default URL for the external ONNX data file that accompanies <see cref="DefaultModelUrl"/>.
         /// Hugging Face splits Harrier ONNX models into a small graph file plus a separate weights file.
         /// </summary>
-        public const string DefaultModelDataUrl = "https://models.curiosity.ai/harrier-model_quantized.onnx_data";
+        public const string DefaultModelDataUrl =  Quantizations.QuantizedModelDataUrl;
 
         /// <summary>
         /// Download URLs for the Harrier 0.6b ONNX model variants published by
@@ -40,7 +40,7 @@ namespace SentenceTransformers.Harrier
         /// </summary>
         public static class Quantizations
         {
-            private const string BaseUrl = "https://huggingface.co/onnx-community/harrier-oss-v1-0.6b-ONNX/resolve/main/onnx/";
+            private const string BaseUrl = "https://models.curiosity.ai/harrier-oss-v1-0.6b-onnx/";
 
             /// <summary>Full-precision (fp32) graph (~2.09 GB external + ~306 MB second weights file).</summary>
             public const string FullModelUrl              = BaseUrl + "model.onnx";

--- a/SentenceTransformers.Test/HarrierVariantsTest.cs
+++ b/SentenceTransformers.Test/HarrierVariantsTest.cs
@@ -1,9 +1,9 @@
 using SentenceTransformers;
-using HarrierBig = SentenceTransformers.Harrier;
-using HarrierSmall = SentenceTransformers.HarrierSmall;
+using HarrierMedium = SentenceTransformers.Harrier.Medium;
+using HarrierSmall = SentenceTransformers.Harrier.Small;
 
 /// <summary>
-/// Integration test: downloads every published quantization variant for both Harrier
+/// Integration test: downloads every published quantization variant for both Harrier Medium
 /// (0.6b) and Harrier Small (270m), loads each, encodes a small batch of multilingual
 /// sentences, and prints the resulting embedding dimensions and a few cosine
 /// similarities so the variants can be eyeballed against each other.
@@ -12,7 +12,7 @@ public static class HarrierVariantsTest
 {
     public static async Task RunAsync()
     {
-        // Both SentenceTransformers.Harrier and SentenceTransformers.Harrier.Small ship a
+        // Both SentenceTransformers.Harrier.Medium and SentenceTransformers.Harrier.Small ship a
         // Resources/tokenizer.json that copies to the same path in the consumer's output, and
         // they collide non-deterministically. Delete the colliding file so each encoder falls
         // back to its own embedded tokenizer (extracted under Path.GetTempPath() per package).
@@ -49,26 +49,26 @@ public static class HarrierVariantsTest
         }
 
         Console.WriteLine();
-        Console.WriteLine("=== Harrier (0.6b) variants ===");
-        foreach (var (label, modelUrl, dataUrls) in HarrierBigVariants())
+        Console.WriteLine("=== Harrier Medium (0.6b) variants ===");
+        foreach (var (label, modelUrl, dataUrls) in HarrierMediumVariants())
         {
             await RunVariantAsync(
                 label,
                 async () =>
                 {
-                    var dir = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Variants", label);
+                    var dir = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Medium.Variants", label);
                     Directory.CreateDirectory(dir);
                     var graphFile = Path.GetFileName(new Uri(modelUrl).LocalPath);
                     var path = Path.Combine(dir, graphFile);
                     // Manually pre-fetch every weight file under its upstream filename, since
                     // CreateAsync only fetches one companion file.
-                    await HarrierBig.SentenceEncoder.DownloadModelAsync(modelUrl, path);
+                    await HarrierMedium.SentenceEncoder.DownloadModelAsync(modelUrl, path);
                     foreach (var d in dataUrls)
                     {
                         var dataPath = Path.Combine(dir, Path.GetFileName(new Uri(d).LocalPath));
-                        await HarrierBig.SentenceEncoder.DownloadModelAsync(d, dataPath);
+                        await HarrierMedium.SentenceEncoder.DownloadModelAsync(d, dataPath);
                     }
-                    return new HarrierBig.SentenceEncoder(modelOnnxPath: path);
+                    return new HarrierMedium.SentenceEncoder(modelOnnxPath: path);
                 },
                 sentences);
         }
@@ -108,13 +108,13 @@ public static class HarrierVariantsTest
         ("quantized",     HarrierSmall.SentenceEncoder.Quantizations.QuantizedModelUrl, HarrierSmall.SentenceEncoder.Quantizations.QuantizedModelDataUrl),
     };
 
-    private static IEnumerable<(string Label, string ModelUrl, string[] DataUrls)> HarrierBigVariants() => new[]
+    private static IEnumerable<(string Label, string ModelUrl, string[] DataUrls)> HarrierMediumVariants() => new[]
     {
-        ("full",      HarrierBig.SentenceEncoder.Quantizations.FullModelUrl,      new[] { HarrierBig.SentenceEncoder.Quantizations.FullModelDataUrl, HarrierBig.SentenceEncoder.Quantizations.FullModelDataUrl2 }),
-        ("fp16",      HarrierBig.SentenceEncoder.Quantizations.Fp16ModelUrl,      new[] { HarrierBig.SentenceEncoder.Quantizations.Fp16ModelDataUrl }),
-        ("q4",        HarrierBig.SentenceEncoder.Quantizations.Q4ModelUrl,        new[] { HarrierBig.SentenceEncoder.Quantizations.Q4ModelDataUrl }),
-        ("q4f16",     HarrierBig.SentenceEncoder.Quantizations.Q4Fp16ModelUrl,    new[] { HarrierBig.SentenceEncoder.Quantizations.Q4Fp16ModelDataUrl }),
-        ("quantized", HarrierBig.SentenceEncoder.Quantizations.QuantizedModelUrl, new[] { HarrierBig.SentenceEncoder.Quantizations.QuantizedModelDataUrl }),
+        ("full",      HarrierMedium.SentenceEncoder.Quantizations.FullModelUrl,      new[] { HarrierMedium.SentenceEncoder.Quantizations.FullModelDataUrl, HarrierMedium.SentenceEncoder.Quantizations.FullModelDataUrl2 }),
+        ("fp16",      HarrierMedium.SentenceEncoder.Quantizations.Fp16ModelUrl,      new[] { HarrierMedium.SentenceEncoder.Quantizations.Fp16ModelDataUrl }),
+        ("q4",        HarrierMedium.SentenceEncoder.Quantizations.Q4ModelUrl,        new[] { HarrierMedium.SentenceEncoder.Quantizations.Q4ModelDataUrl }),
+        ("q4f16",     HarrierMedium.SentenceEncoder.Quantizations.Q4Fp16ModelUrl,    new[] { HarrierMedium.SentenceEncoder.Quantizations.Q4Fp16ModelDataUrl }),
+        ("quantized", HarrierMedium.SentenceEncoder.Quantizations.QuantizedModelUrl, new[] { HarrierMedium.SentenceEncoder.Quantizations.QuantizedModelDataUrl }),
     };
 
     private static float Dot(float[] a, float[] b)

--- a/SentenceTransformers.Test/HarrierVariantsTest.cs
+++ b/SentenceTransformers.Test/HarrierVariantsTest.cs
@@ -1,0 +1,128 @@
+using SentenceTransformers;
+using HarrierBig = SentenceTransformers.Harrier;
+using HarrierSmall = SentenceTransformers.HarrierSmall;
+
+/// <summary>
+/// Integration test: downloads every published quantization variant for both Harrier
+/// (0.6b) and Harrier Small (270m), loads each, encodes a small batch of multilingual
+/// sentences, and prints the resulting embedding dimensions and a few cosine
+/// similarities so the variants can be eyeballed against each other.
+/// </summary>
+public static class HarrierVariantsTest
+{
+    public static async Task RunAsync()
+    {
+        // Both SentenceTransformers.Harrier and SentenceTransformers.Harrier.Small ship a
+        // Resources/tokenizer.json that copies to the same path in the consumer's output, and
+        // they collide non-deterministically. Delete the colliding file so each encoder falls
+        // back to its own embedded tokenizer (extracted under Path.GetTempPath() per package).
+        var collidingTokenizer = Path.Combine(AppContext.BaseDirectory, "Resources", "tokenizer.json");
+        if (File.Exists(collidingTokenizer))
+        {
+            File.Delete(collidingTokenizer);
+            Console.WriteLine($"(removed colliding {collidingTokenizer})");
+        }
+
+        var sentences = new[]
+        {
+            "Good morning, how are you?",   // English
+            "Buenos días, ¿cómo estás?",    // Spanish
+            "おはようございます、お元気ですか？", // Japanese
+            "Hello world",                   // unrelated
+            "The cat sat on the mat",        // unrelated
+        };
+
+        Console.WriteLine("=== Harrier Small (270m) variants ===");
+        foreach (var (label, modelUrl, dataUrl) in HarrierSmallVariants())
+        {
+            await RunVariantAsync(
+                label,
+                async () =>
+                {
+                    var dir = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small.Variants", label);
+                    Directory.CreateDirectory(dir);
+                    var graphFile = Path.GetFileName(new Uri(modelUrl).LocalPath);
+                    var path = Path.Combine(dir, graphFile);
+                    return await HarrierSmall.SentenceEncoder.CreateAsync(modelUrl: modelUrl, modelDataUrl: dataUrl, downloadToPath: path);
+                },
+                sentences);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("=== Harrier (0.6b) variants ===");
+        foreach (var (label, modelUrl, dataUrls) in HarrierBigVariants())
+        {
+            await RunVariantAsync(
+                label,
+                async () =>
+                {
+                    var dir = Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Variants", label);
+                    Directory.CreateDirectory(dir);
+                    var graphFile = Path.GetFileName(new Uri(modelUrl).LocalPath);
+                    var path = Path.Combine(dir, graphFile);
+                    // Manually pre-fetch every weight file under its upstream filename, since
+                    // CreateAsync only fetches one companion file.
+                    await HarrierBig.SentenceEncoder.DownloadModelAsync(modelUrl, path);
+                    foreach (var d in dataUrls)
+                    {
+                        var dataPath = Path.Combine(dir, Path.GetFileName(new Uri(d).LocalPath));
+                        await HarrierBig.SentenceEncoder.DownloadModelAsync(d, dataPath);
+                    }
+                    return new HarrierBig.SentenceEncoder(modelOnnxPath: path);
+                },
+                sentences);
+        }
+    }
+
+    private static async Task RunVariantAsync(string label, Func<Task<ISentenceEncoder>> factory, string[] sentences)
+    {
+        Console.WriteLine($"--- {label} ---");
+        try
+        {
+            using var enc = await factory();
+            var vectors = await enc.EncodeAsync(sentences);
+            Console.WriteLine($"  embedding dim: {vectors[0].Length}");
+            // Print every pairwise cosine similarity so quantization quality is visible.
+            for (int i = 0; i < vectors.Length; i++)
+            {
+                for (int j = i + 1; j < vectors.Length; j++)
+                {
+                    var sim = Dot(vectors[i], vectors[j]);
+                    Console.WriteLine($"  sim({i},{j}) = {sim:F4}  ({Trim(sentences[i])} vs {Trim(sentences[j])})");
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"  FAILED: {e.Message}");
+            throw;
+        }
+    }
+
+    private static IEnumerable<(string Label, string ModelUrl, string DataUrl)> HarrierSmallVariants() => new[]
+    {
+        ("full",          HarrierSmall.SentenceEncoder.Quantizations.FullModelUrl,    HarrierSmall.SentenceEncoder.Quantizations.FullModelDataUrl),
+        ("fp16",          HarrierSmall.SentenceEncoder.Quantizations.Fp16ModelUrl,    HarrierSmall.SentenceEncoder.Quantizations.Fp16ModelDataUrl),
+        ("q4",            HarrierSmall.SentenceEncoder.Quantizations.Q4ModelUrl,      HarrierSmall.SentenceEncoder.Quantizations.Q4ModelDataUrl),
+        ("q4f16",         HarrierSmall.SentenceEncoder.Quantizations.Q4Fp16ModelUrl,  HarrierSmall.SentenceEncoder.Quantizations.Q4Fp16ModelDataUrl),
+        ("quantized",     HarrierSmall.SentenceEncoder.Quantizations.QuantizedModelUrl, HarrierSmall.SentenceEncoder.Quantizations.QuantizedModelDataUrl),
+    };
+
+    private static IEnumerable<(string Label, string ModelUrl, string[] DataUrls)> HarrierBigVariants() => new[]
+    {
+        ("full",      HarrierBig.SentenceEncoder.Quantizations.FullModelUrl,      new[] { HarrierBig.SentenceEncoder.Quantizations.FullModelDataUrl, HarrierBig.SentenceEncoder.Quantizations.FullModelDataUrl2 }),
+        ("fp16",      HarrierBig.SentenceEncoder.Quantizations.Fp16ModelUrl,      new[] { HarrierBig.SentenceEncoder.Quantizations.Fp16ModelDataUrl }),
+        ("q4",        HarrierBig.SentenceEncoder.Quantizations.Q4ModelUrl,        new[] { HarrierBig.SentenceEncoder.Quantizations.Q4ModelDataUrl }),
+        ("q4f16",     HarrierBig.SentenceEncoder.Quantizations.Q4Fp16ModelUrl,    new[] { HarrierBig.SentenceEncoder.Quantizations.Q4Fp16ModelDataUrl }),
+        ("quantized", HarrierBig.SentenceEncoder.Quantizations.QuantizedModelUrl, new[] { HarrierBig.SentenceEncoder.Quantizations.QuantizedModelDataUrl }),
+    };
+
+    private static float Dot(float[] a, float[] b)
+    {
+        float s = 0f;
+        for (int i = 0; i < a.Length; i++) s += a[i] * b[i];
+        return s;
+    }
+
+    private static string Trim(string s) => s.Length > 30 ? s.Substring(0, 27) + "..." : s;
+}

--- a/SentenceTransformers.Test/Program.cs
+++ b/SentenceTransformers.Test/Program.cs
@@ -2,8 +2,17 @@ using System.Diagnostics;
 using System.Text;
 using SentenceTransformers;
 
+// Set SENTENCE_TRANSFORMERS_TEST=harrier-variants to download and validate every Harrier
+// quantization variant published on Hugging Face. Otherwise run the normal smoke test.
+if (string.Equals(Environment.GetEnvironmentVariable("SENTENCE_TRANSFORMERS_TEST"), "harrier-variants", StringComparison.OrdinalIgnoreCase))
+{
+    await HarrierVariantsTest.RunAsync();
+    return;
+}
+
 var qwenEncTask = SentenceTransformers.Qwen3.SentenceEncoder.CreateAsync();
 var harrierEncTask = SentenceTransformers.Harrier.SentenceEncoder.CreateAsync();
+var harrierSmallEncTask = SentenceTransformers.HarrierSmall.SentenceEncoder.CreateAsync();
 
 await Main.RunSimple(new SentenceTransformers.MiniLM.SentenceEncoder());
 await Main.RunSimple(new SentenceTransformers.ArcticXs.SentenceEncoder());
@@ -16,6 +25,11 @@ using (var qwenEnc = await qwenEncTask)
 using (var harrierEnc = await harrierEncTask)
 {
     await Main.RunSimple(harrierEnc);
+}
+
+using (var harrierSmallEnc = await harrierSmallEncTask)
+{
+    await Main.RunSimple(harrierSmallEnc);
 }
 
 public static class Main

--- a/SentenceTransformers.Test/Program.cs
+++ b/SentenceTransformers.Test/Program.cs
@@ -11,8 +11,8 @@ if (string.Equals(Environment.GetEnvironmentVariable("SENTENCE_TRANSFORMERS_TEST
 }
 
 var qwenEncTask = SentenceTransformers.Qwen3.SentenceEncoder.CreateAsync();
-var harrierEncTask = SentenceTransformers.Harrier.SentenceEncoder.CreateAsync();
-var harrierSmallEncTask = SentenceTransformers.HarrierSmall.SentenceEncoder.CreateAsync();
+var harrierMediumEncTask = SentenceTransformers.Harrier.Medium.SentenceEncoder.CreateAsync();
+var harrierSmallEncTask = SentenceTransformers.Harrier.Small.SentenceEncoder.CreateAsync();
 
 await Main.RunSimple(new SentenceTransformers.MiniLM.SentenceEncoder());
 await Main.RunSimple(new SentenceTransformers.ArcticXs.SentenceEncoder());
@@ -22,9 +22,9 @@ using (var qwenEnc = await qwenEncTask)
     await Main.RunSimple(qwenEnc);
 }
 
-using (var harrierEnc = await harrierEncTask)
+using (var harrierMediumEnc = await harrierMediumEncTask)
 {
-    await Main.RunSimple(harrierEnc);
+    await Main.RunSimple(harrierMediumEnc);
 }
 
 using (var harrierSmallEnc = await harrierSmallEncTask)

--- a/SentenceTransformers.Test/SentenceTransformers.Test.csproj
+++ b/SentenceTransformers.Test/SentenceTransformers.Test.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\SentenceTransformers\SentenceTransformers.csproj" />
     <ProjectReference Include="..\SentenceTransformers.MiniLM\SentenceTransformers.MiniLM.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Qwen3\SentenceTransformers.Qwen3.csproj" />
-    <ProjectReference Include="..\SentenceTransformers.Harrier\SentenceTransformers.Harrier.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier.Medium\SentenceTransformers.Harrier.Medium.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Harrier.Small\SentenceTransformers.Harrier.Small.csproj" />
     <ProjectReference Include="..\SentenceTransformers.ArcticXs\SentenceTransformers.ArcticXs.csproj" />
   </ItemGroup>

--- a/SentenceTransformers.Test/SentenceTransformers.Test.csproj
+++ b/SentenceTransformers.Test/SentenceTransformers.Test.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\SentenceTransformers.MiniLM\SentenceTransformers.MiniLM.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Qwen3\SentenceTransformers.Qwen3.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Harrier\SentenceTransformers.Harrier.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier.Small\SentenceTransformers.Harrier.Small.csproj" />
     <ProjectReference Include="..\SentenceTransformers.ArcticXs\SentenceTransformers.ArcticXs.csproj" />
   </ItemGroup>
 </Project>

--- a/SentenceTransformers.Tests/BPEChunkingHelpersTests.cs
+++ b/SentenceTransformers.Tests/BPEChunkingHelpersTests.cs
@@ -1,4 +1,4 @@
-using SentenceTransformers.Harrier;
+using SentenceTransformers.Harrier.Medium;
 using SentenceTransformers.Qwen3;
 using SentenceTransformers.Tests.Support;
 
@@ -6,15 +6,15 @@ namespace SentenceTransformers.Tests;
 
 /// <summary>
 /// Tests for <see cref="BPEChunkAndEncodeHelpers"/>: the offset-based chunker used by Qwen3 and
-/// Harrier. The chunk text must always equal the source substring between the first and last
-/// token's offsets — preserving whitespace, punctuation, and any injected markers verbatim.
+/// Harrier Medium. The chunk text must always equal the source substring between the first and
+/// last token's offsets — preserving whitespace, punctuation, and any injected markers verbatim.
 /// </summary>
 public class BPEChunkingHelpersTests
 {
     private const int MaxTokens = 1024;
 
     private static QwenTokenizer NewQwen() => new(TestPaths.QwenTokenizerJson, MaxTokens);
-    private static HarrierTokenizer NewHarrier() => new(TestPaths.HarrierTokenizerJson, MaxTokens);
+    private static HarrierMediumTokenizer NewHarrierMedium() => new(TestPaths.HarrierMediumTokenizerJson, MaxTokens);
 
     [Fact]
     public void ChunkTokens_EmptyText_ReturnsEmpty()
@@ -131,9 +131,9 @@ public class BPEChunkingHelpersTests
     }
 
     [Fact]
-    public void ChunkTokensAligned_Harrier_PreservesUnicodeContent()
+    public void ChunkTokensAligned_HarrierMedium_PreservesUnicodeContent()
     {
-        using var tok = NewHarrier();
+        using var tok = NewHarrierMedium();
         // Mix of scripts to exercise multi-byte handling.
         var text = "English text. Texte français. 中文文本。 العربية. русский.";
         var aligned = BPEChunkAndEncodeHelpers.ChunkTokensAligned(tok, text, chunkLength: 8, chunkOverlap: 2);

--- a/SentenceTransformers.Tests/BPETokenizerTests.cs
+++ b/SentenceTransformers.Tests/BPETokenizerTests.cs
@@ -1,13 +1,14 @@
 using SentenceTransformers.Harrier;
+using SentenceTransformers.HarrierSmall;
 using SentenceTransformers.Qwen3;
 using SentenceTransformers.Tests.Support;
 
 namespace SentenceTransformers.Tests;
 
 /// <summary>
-/// Tests for the Hugging Face byte-level BPE tokenizers used by Qwen3 and Harrier. The tests
-/// construct the tokenizers directly from the shipped <c>tokenizer.json</c> files (no ONNX model
-/// is loaded).
+/// Tests for the Hugging Face byte-level BPE tokenizers used by Qwen3, Harrier and Harrier.Small.
+/// The tests construct the tokenizers directly from the shipped <c>tokenizer.json</c> files (no
+/// ONNX model is loaded).
 /// </summary>
 public class BPETokenizerTests
 {
@@ -150,6 +151,45 @@ public class BPETokenizerTests
     public void HarrierTokenizer_TokenizeSimple_NotEmpty()
     {
         using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        var tokens = tok.TokenizeSimple("Embeddings for multilingual text");
+        Assert.NotEmpty(tokens);
+    }
+
+    [Fact]
+    public void HarrierSmallTokenizer_TokenizeRaw_OriginalsConcatenateToSource()
+    {
+        using var tok = new HarrierSmallTokenizer(TestPaths.HarrierSmallTokenizerJson, MaxTokens);
+        var text = "Multilingual embeddings test 123.";
+        var raw = tok.TokenizeRaw(text);
+        var concat = string.Concat(raw.Select(t => t.Original ?? string.Empty));
+        Assert.Equal(text, concat);
+    }
+
+    [Fact]
+    public void HarrierSmallTokenizer_TokenizeRawAligned_OffsetsCoverSource()
+    {
+        using var tok = new HarrierSmallTokenizer(TestPaths.HarrierSmallTokenizerJson, MaxTokens);
+        var text = "Bonjour le monde, ceci est un test.";
+        var aligned = tok.TokenizeRawAligned(text);
+        Assert.NotEmpty(aligned);
+        Assert.Equal(0, aligned[0].Start);
+        Assert.Equal(text.Length, aligned[^1].ApproximateEnd);
+    }
+
+    [Fact]
+    public void HarrierSmallTokenizer_Encode_ProducesAlignedArrays()
+    {
+        using var tok = new HarrierSmallTokenizer(TestPaths.HarrierSmallTokenizerJson, MaxTokens);
+        var encoded = tok.Encode(["hello world"]);
+        Assert.Single(encoded);
+        Assert.Equal(encoded[0].InputIds.Length, encoded[0].AttentionMask.Length);
+        Assert.Equal(encoded[0].InputIds.Length, encoded[0].TokenTypeIds.Length);
+    }
+
+    [Fact]
+    public void HarrierSmallTokenizer_TokenizeSimple_NotEmpty()
+    {
+        using var tok = new HarrierSmallTokenizer(TestPaths.HarrierSmallTokenizerJson, MaxTokens);
         var tokens = tok.TokenizeSimple("Embeddings for multilingual text");
         Assert.NotEmpty(tokens);
     }

--- a/SentenceTransformers.Tests/BPETokenizerTests.cs
+++ b/SentenceTransformers.Tests/BPETokenizerTests.cs
@@ -1,14 +1,14 @@
-using SentenceTransformers.Harrier;
-using SentenceTransformers.HarrierSmall;
+using SentenceTransformers.Harrier.Medium;
+using SentenceTransformers.Harrier.Small;
 using SentenceTransformers.Qwen3;
 using SentenceTransformers.Tests.Support;
 
 namespace SentenceTransformers.Tests;
 
 /// <summary>
-/// Tests for the Hugging Face byte-level BPE tokenizers used by Qwen3, Harrier and Harrier.Small.
-/// The tests construct the tokenizers directly from the shipped <c>tokenizer.json</c> files (no
-/// ONNX model is loaded).
+/// Tests for the Hugging Face byte-level BPE tokenizers used by Qwen3, Harrier Medium and
+/// Harrier Small. The tests construct the tokenizers directly from the shipped
+/// <c>tokenizer.json</c> files (no ONNX model is loaded).
 /// </summary>
 public class BPETokenizerTests
 {
@@ -117,9 +117,9 @@ public class BPETokenizerTests
     }
 
     [Fact]
-    public void HarrierTokenizer_TokenizeRaw_OriginalsConcatenateToSource()
+    public void HarrierMediumTokenizer_TokenizeRaw_OriginalsConcatenateToSource()
     {
-        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        using var tok = new HarrierMediumTokenizer(TestPaths.HarrierMediumTokenizerJson, MaxTokens);
         var text = "Multilingual embeddings test 123.";
         var raw = tok.TokenizeRaw(text);
         var concat = string.Concat(raw.Select(t => t.Original ?? string.Empty));
@@ -127,9 +127,9 @@ public class BPETokenizerTests
     }
 
     [Fact]
-    public void HarrierTokenizer_TokenizeRawAligned_OffsetsCoverSource()
+    public void HarrierMediumTokenizer_TokenizeRawAligned_OffsetsCoverSource()
     {
-        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        using var tok = new HarrierMediumTokenizer(TestPaths.HarrierMediumTokenizerJson, MaxTokens);
         var text = "Bonjour le monde, ceci est un test.";
         var aligned = tok.TokenizeRawAligned(text);
         Assert.NotEmpty(aligned);
@@ -138,9 +138,9 @@ public class BPETokenizerTests
     }
 
     [Fact]
-    public void HarrierTokenizer_Encode_ProducesAlignedArrays()
+    public void HarrierMediumTokenizer_Encode_ProducesAlignedArrays()
     {
-        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        using var tok = new HarrierMediumTokenizer(TestPaths.HarrierMediumTokenizerJson, MaxTokens);
         var encoded = tok.Encode(["hello world"]);
         Assert.Single(encoded);
         Assert.Equal(encoded[0].InputIds.Length, encoded[0].AttentionMask.Length);
@@ -148,9 +148,9 @@ public class BPETokenizerTests
     }
 
     [Fact]
-    public void HarrierTokenizer_TokenizeSimple_NotEmpty()
+    public void HarrierMediumTokenizer_TokenizeSimple_NotEmpty()
     {
-        using var tok = new HarrierTokenizer(TestPaths.HarrierTokenizerJson, MaxTokens);
+        using var tok = new HarrierMediumTokenizer(TestPaths.HarrierMediumTokenizerJson, MaxTokens);
         var tokens = tok.TokenizeSimple("Embeddings for multilingual text");
         Assert.NotEmpty(tokens);
     }

--- a/SentenceTransformers.Tests/SentenceTransformers.Tests.csproj
+++ b/SentenceTransformers.Tests/SentenceTransformers.Tests.csproj
@@ -20,12 +20,12 @@
     <ProjectReference Include="..\SentenceTransformers.MiniLM\SentenceTransformers.MiniLM.csproj" />
     <ProjectReference Include="..\SentenceTransformers.ArcticXs\SentenceTransformers.ArcticXs.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Qwen3\SentenceTransformers.Qwen3.csproj" />
-    <ProjectReference Include="..\SentenceTransformers.Harrier\SentenceTransformers.Harrier.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier.Medium\SentenceTransformers.Harrier.Medium.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Harrier.Small\SentenceTransformers.Harrier.Small.csproj" />
   </ItemGroup>
 
   <!--
-    Qwen, Harrier and Harrier.Small each ship Resources\tokenizer.json. Referencing all three
+    Qwen, Harrier.Medium and Harrier.Small each ship Resources\tokenizer.json. Referencing all three
     projects copies them to the same output path; we instead link the source tokenizer.json files
     under distinct filenames so tests can load each by path.
   -->
@@ -33,7 +33,7 @@
     <None Include="..\SentenceTransformers.Qwen3\Resources\tokenizer.json" Link="Resources\qwen-tokenizer.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\SentenceTransformers.Harrier\Resources\tokenizer.json" Link="Resources\harrier-tokenizer.json">
+    <None Include="..\SentenceTransformers.Harrier.Medium\Resources\tokenizer.json" Link="Resources\harrier-medium-tokenizer.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\SentenceTransformers.Harrier.Small\Resources\tokenizer.json" Link="Resources\harrier-small-tokenizer.json">

--- a/SentenceTransformers.Tests/SentenceTransformers.Tests.csproj
+++ b/SentenceTransformers.Tests/SentenceTransformers.Tests.csproj
@@ -21,18 +21,22 @@
     <ProjectReference Include="..\SentenceTransformers.ArcticXs\SentenceTransformers.ArcticXs.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Qwen3\SentenceTransformers.Qwen3.csproj" />
     <ProjectReference Include="..\SentenceTransformers.Harrier\SentenceTransformers.Harrier.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier.Small\SentenceTransformers.Harrier.Small.csproj" />
   </ItemGroup>
 
   <!--
-    Qwen and Harrier both ship Resources\tokenizer.json. Referencing both projects copies them to
-    the same output path; we instead link the source tokenizer.json files under distinct filenames
-    so tests can load each by path.
+    Qwen, Harrier and Harrier.Small each ship Resources\tokenizer.json. Referencing all three
+    projects copies them to the same output path; we instead link the source tokenizer.json files
+    under distinct filenames so tests can load each by path.
   -->
   <ItemGroup>
     <None Include="..\SentenceTransformers.Qwen3\Resources\tokenizer.json" Link="Resources\qwen-tokenizer.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\SentenceTransformers.Harrier\Resources\tokenizer.json" Link="Resources\harrier-tokenizer.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\SentenceTransformers.Harrier.Small\Resources\tokenizer.json" Link="Resources\harrier-small-tokenizer.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/SentenceTransformers.Tests/Support/TestPaths.cs
+++ b/SentenceTransformers.Tests/Support/TestPaths.cs
@@ -4,4 +4,5 @@ internal static class TestPaths
 {
     public static string QwenTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "qwen-tokenizer.json");
     public static string HarrierTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "harrier-tokenizer.json");
+    public static string HarrierSmallTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "harrier-small-tokenizer.json");
 }

--- a/SentenceTransformers.Tests/Support/TestPaths.cs
+++ b/SentenceTransformers.Tests/Support/TestPaths.cs
@@ -3,6 +3,6 @@ namespace SentenceTransformers.Tests.Support;
 internal static class TestPaths
 {
     public static string QwenTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "qwen-tokenizer.json");
-    public static string HarrierTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "harrier-tokenizer.json");
-    public static string HarrierSmallTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "harrier-small-tokenizer.json");
+    public static string HarrierMediumTokenizerJson => Path.Combine(AppContext.BaseDirectory, "Resources", "harrier-medium-tokenizer.json");
+    public static string HarrierSmallTokenizerJson  => Path.Combine(AppContext.BaseDirectory, "Resources", "harrier-small-tokenizer.json");
 }

--- a/SentenceTransformers.sln
+++ b/SentenceTransformers.sln
@@ -26,7 +26,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Benchm
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing", "Testing", "{9ACE82CD-C6FE-43D9-8B0F-9941FF3DE333}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Harrier", "SentenceTransformers.Harrier\SentenceTransformers.Harrier.csproj", "{AD66CF6D-160C-4B5E-9BAF-D7A2CDB6FC49}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Harrier.Medium", "SentenceTransformers.Harrier.Medium\SentenceTransformers.Harrier.Medium.csproj", "{AD66CF6D-160C-4B5E-9BAF-D7A2CDB6FC49}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Tests", "SentenceTransformers.Tests\SentenceTransformers.Tests.csproj", "{11CAD661-6EE5-41FA-812E-AECBE3F813F1}"
 EndProject

--- a/SentenceTransformers.sln
+++ b/SentenceTransformers.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Harrie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Tests", "SentenceTransformers.Tests\SentenceTransformers.Tests.csproj", "{11CAD661-6EE5-41FA-812E-AECBE3F813F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Harrier.Small", "SentenceTransformers.Harrier.Small\SentenceTransformers.Harrier.Small.csproj", "{9F327C13-6CF0-4AB1-82DC-EA91776975B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -160,6 +162,18 @@ Global
 		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|x64.Build.0 = Release|Any CPU
 		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|x86.ActiveCfg = Release|Any CPU
 		{11CAD661-6EE5-41FA-812E-AECBE3F813F1}.Release|x86.Build.0 = Release|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Debug|x86.Build.0 = Debug|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Release|x64.Build.0 = Release|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{9F327C13-6CF0-4AB1-82DC-EA91776975B2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

- New `SentenceTransformers.Harrier.Small` package wrapping [microsoft/harrier-oss-v1-270m](https://huggingface.co/microsoft/harrier-oss-v1-270m) — Gemma3-based, 640-dim, up to 32k tokens, multilingual. Weights download on first use; tokenizer.json (20 MB) ships in the package.
- Existing `SentenceTransformers.Harrier` package renamed to `SentenceTransformers.Harrier.Medium` for consistency with `.Small`. C# namespace, class names (`HarrierTokenizer` → `HarrierMediumTokenizer`), tokenizer-collision filenames, and the Azure pipeline variable all renamed to match. No backwards-compatibility shims.
- Per-quantization URL constants on both `SentenceTransformers.Harrier.Medium.SentenceEncoder.Quantizations` and `SentenceTransformers.Harrier.Small.SentenceEncoder.Quantizations` (Full / FP16 / Q4 / Q4F16 / Quantized). URLs currently point at the upstream Hugging Face `.onnx` / `.onnx_data` files; the default constants are already updated to a curiosity.ai mirror in [50e00bb](https://github.com/curiosity-ai/sentence-transformers-sharp/commit/50e00bb).
- `.devops/azure-pipelines.yml` adds the missing Harrier.Small build/pack step alongside the renamed Harrier.Medium step.
- `SentenceTransformers.Test` gains a `HarrierVariantsTest` (run with `SENTENCE_TRANSFORMERS_TEST=harrier-variants`) that downloads every published quantization variant for both Harrier sizes, runs each, and prints embedding dim + cross-lingual cosine similarities so quality can be eyeballed. All 10 variants validated locally.
- New tokenizer unit tests for the 270m vocab in `SentenceTransformers.Tests`.
- README updated with the new package, a usage snippet, and a quantization table.

## Test plan

- [x] `dotnet build SentenceTransformers.sln`
- [x] `dotnet test SentenceTransformers.Tests/SentenceTransformers.Tests.csproj` — 49 tests pass (4 new HarrierSmall tokenizer tests, all existing tests renamed)
- [x] `SENTENCE_TRANSFORMERS_TEST=harrier-variants dotnet run --project SentenceTransformers.Test` — all 10 Harrier.Medium / Harrier.Small quantization variants load and produce sensible multilingual embeddings (cross-lingual sims ~0.7+ for "good morning" in en/es/jp)
- [x] Local pack + Mosaik.Graph build verified against the renamed packages
- [ ] CI green

https://claude.ai/code/session_01R6qwrDwSigbM238ngVnQxn