### PR TITLE
Default Harrier downloads to Q4F16, link all NuGet packages, add download progress callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ float[][] vectors = await encoder.EncodeAsync(new[]
 
 | Package | Model | Dimensions | Max tokens | Languages | Weights |
 | --- | --- | --- | --- | --- | --- |
-| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.svg?label=SentenceTransformers)](https://www.nuget.org/packages/SentenceTransformers/) | Core interfaces & chunking helpers | — | — | — | — |
-| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.MiniLM.svg?label=SentenceTransformers.MiniLM)](https://www.nuget.org/packages/SentenceTransformers.MiniLM/) | [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) | 384 | 256 | English | Embedded |
-| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.ArcticXs.svg?label=SentenceTransformers.ArcticXs)](https://www.nuget.org/packages/SentenceTransformers.ArcticXs/) | [snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs) | 384 | 512 | English | Embedded |
-| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Qwen3.svg?label=SentenceTransformers.Qwen3)](https://www.nuget.org/packages/SentenceTransformers.Qwen3/) | [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) | 1024 | 32768 | Multilingual | Downloaded on first use |
-| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.Medium.svg?label=SentenceTransformers.Harrier.Medium)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Medium/) | [harrier-oss-v1-0.6b](https://huggingface.co/onnx-community/harrier-oss-v1-0.6b-ONNX) | 1024 | 32768 | Multilingual | Downloaded on first use |
-| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.Small.svg?label=SentenceTransformers.Harrier.Small)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Small/) | [harrier-oss-v1-270m](https://huggingface.co/onnx-community/harrier-oss-v1-270m-ONNX) | 640 | 32768 | Multilingual | Downloaded on first use |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.svg?label=SentenceTransformers)](https://www.nuget.org/packages/SentenceTransformers/) [![Downloads](https://img.shields.io/nuget/dt/SentenceTransformers.svg?label=)](https://www.nuget.org/packages/SentenceTransformers/) | Core interfaces & chunking helpers | — | — | — | — |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.MiniLM.svg?label=SentenceTransformers.MiniLM)](https://www.nuget.org/packages/SentenceTransformers.MiniLM/) [![Downloads](https://img.shields.io/nuget/dt/SentenceTransformers.MiniLM.svg?label=)](https://www.nuget.org/packages/SentenceTransformers.MiniLM/) | [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) | 384 | 256 | English | Embedded |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.ArcticXs.svg?label=SentenceTransformers.ArcticXs)](https://www.nuget.org/packages/SentenceTransformers.ArcticXs/) [![Downloads](https://img.shields.io/nuget/dt/SentenceTransformers.ArcticXs.svg?label=)](https://www.nuget.org/packages/SentenceTransformers.ArcticXs/) | [snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs) | 384 | 512 | English | Embedded |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Qwen3.svg?label=SentenceTransformers.Qwen3)](https://www.nuget.org/packages/SentenceTransformers.Qwen3/) [![Downloads](https://img.shields.io/nuget/dt/SentenceTransformers.Qwen3.svg?label=)](https://www.nuget.org/packages/SentenceTransformers.Qwen3/) | [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) | 1024 | 32768 | Multilingual | Downloaded on first use |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.Medium.svg?label=SentenceTransformers.Harrier.Medium)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Medium/) [![Downloads](https://img.shields.io/nuget/dt/SentenceTransformers.Harrier.Medium.svg?label=)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Medium/) | [harrier-oss-v1-0.6b](https://huggingface.co/onnx-community/harrier-oss-v1-0.6b-ONNX) | 1024 | 32768 | Multilingual | Downloaded on first use |
+| [![NuGet](https://img.shields.io/nuget/v/SentenceTransformers.Harrier.Small.svg?label=SentenceTransformers.Harrier.Small)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Small/) [![Downloads](https://img.shields.io/nuget/dt/SentenceTransformers.Harrier.Small.svg?label=)](https://www.nuget.org/packages/SentenceTransformers.Harrier.Small/) | [harrier-oss-v1-270m](https://huggingface.co/onnx-community/harrier-oss-v1-270m-ONNX) | 640 | 32768 | Multilingual | Downloaded on first use |
 
 - **Embedded** models bundle the ONNX weights inside the NuGet package, so the encoder is ready
   immediately after construction.
@@ -209,27 +209,28 @@ to tune threading or enable hardware execution providers.
 Both Harrier packages ship multiple quantization formats — pick the one that fits your CPU / GPU
 memory budget. URLs for every variant are exposed as constants on `SentenceEncoder.Quantizations`:
 
-| Variant     | Constant                                | Harrier Medium (0.6b) weights | Harrier Small (270m) weights |
-| ---         | ---                                     | ---:                          | ---:                          |
-| Full (fp32) | `Quantizations.FullModelUrl`            | 2.09 GB (+306 MB)             | 1.11 GB                       |
-| FP16        | `Quantizations.Fp16ModelUrl`            | 1.20 GB                       | 553 MB                        |
-| Q4          | `Quantizations.Q4ModelUrl`              | 399 MB                        | 205 MB                        |
-| Q4 + FP16   | `Quantizations.Q4Fp16ModelUrl`          | 353 MB                        | 172 MB                        |
-| Quantized   | `Quantizations.QuantizedModelUrl` *(default)* | 706 MB                  | 344 MB                        |
+| Variant     | Constant                                       | Harrier Medium (0.6b) weights | Harrier Small (270m) weights |
+| ---         | ---                                            | ---:                          | ---:                          |
+| Full (fp32) | `Quantizations.FullModelUrl`                   | 2.09 GB (+306 MB)             | 1.11 GB                       |
+| FP16        | `Quantizations.Fp16ModelUrl`                   | 1.20 GB                       | 553 MB                        |
+| Q4          | `Quantizations.Q4ModelUrl`                     | 399 MB                        | 205 MB                        |
+| Q4 + FP16   | `Quantizations.Q4Fp16ModelUrl` *(default)*     | 353 MB                        | 172 MB                        |
+| Quantized   | `Quantizations.QuantizedModelUrl`              | 706 MB                        | 344 MB                        |
 
-`Quantized` is the default — it produces float32 output and is the most broadly compatible across
-ONNX Runtime execution providers. `Q4` / `Q4F16` are the smallest on disk; `FP16` keeps the most
-precision per byte; `Full` is the unquantized reference. Each entry has a matching
-`…ModelDataUrl` constant for the external weights file (and the Harrier Medium `Full` variant
-additionally has `FullModelDataUrl2` because its fp32 weights are split into two files).
+`Q4F16` is the default — it's the smallest variant on disk and keeps multilingual retrieval quality
+close to the unquantized reference. Pick `Quantized` when you need a pure float32 output and
+broader ONNX-Runtime execution-provider compatibility; `FP16` for the most precision per byte;
+`Full` for the unquantized reference. Each entry has a matching `…ModelDataUrl` constant for the
+external weights file (and the Harrier Medium `Full` variant additionally has `FullModelDataUrl2`
+because its fp32 weights are split into two files).
 
 ```csharp
 using SentenceTransformers.Harrier.Small;
 
-// Use the smallest variant available (Q4F16, ~172 MB):
+// Use the unquantized reference instead of the default Q4F16:
 using var encoder = await SentenceEncoder.CreateAsync(
-    modelUrl:     SentenceEncoder.Quantizations.Q4Fp16ModelUrl,
-    modelDataUrl: SentenceEncoder.Quantizations.Q4Fp16ModelDataUrl);
+    modelUrl:     SentenceEncoder.Quantizations.FullModelUrl,
+    modelDataUrl: SentenceEncoder.Quantizations.FullModelDataUrl);
 ```
 
 ## How it works

--- a/SentenceTransformers.Harrier.Medium/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Medium/src/SentenceEncoder.cs
@@ -19,16 +19,17 @@ namespace SentenceTransformers.Harrier.Medium
     {
         /// <summary>
         /// Default URL used to download the ONNX model when no path is provided.
-        /// Points to the standard quantized variant (~706 MB external data) which produces
-        /// float32 output and is the most broadly compatible with onnxruntime CPU/GPU providers.
+        /// Points to the Q4F16 variant (~353 MB external data), the smallest variant by disk
+        /// size for Harrier Medium. Choose a different <see cref="Quantizations"/> entry when
+        /// you need higher precision or smaller graph latency.
         /// </summary>
-        public const string DefaultModelUrl = Quantizations.QuantizedModelUrl;
+        public const string DefaultModelUrl = Quantizations.Q4Fp16ModelUrl;
 
         /// <summary>
         /// Default URL for the external ONNX data file that accompanies <see cref="DefaultModelUrl"/>.
         /// Hugging Face splits Harrier ONNX models into a small graph file plus a separate weights file.
         /// </summary>
-        public const string DefaultModelDataUrl =  Quantizations.QuantizedModelDataUrl;
+        public const string DefaultModelDataUrl =  Quantizations.Q4Fp16ModelDataUrl;
 
         /// <summary>
         /// Download URLs for the Harrier 0.6b ONNX model variants published by
@@ -59,12 +60,12 @@ namespace SentenceTransformers.Harrier.Medium
             /// <summary>External weights for <see cref="Q4ModelUrl"/>.</summary>
             public const string Q4ModelDataUrl            = BaseUrl + "model_q4.onnx_data";
 
-            /// <summary>4-bit-with-FP16-residual graph (~353 MB external weights).</summary>
+            /// <summary>4-bit-with-FP16-residual graph (~353 MB external weights). The default variant - smallest on disk.</summary>
             public const string Q4Fp16ModelUrl            = BaseUrl + "model_q4f16.onnx";
             /// <summary>External weights for <see cref="Q4Fp16ModelUrl"/>.</summary>
             public const string Q4Fp16ModelDataUrl        = BaseUrl + "model_q4f16.onnx_data";
 
-            /// <summary>Standard quantized graph (~706 MB external weights, fp32 output). The default variant.</summary>
+            /// <summary>Standard quantized graph (~706 MB external weights, fp32 output).</summary>
             public const string QuantizedModelUrl         = BaseUrl + "model_quantized.onnx";
             /// <summary>External weights for <see cref="QuantizedModelUrl"/>.</summary>
             public const string QuantizedModelDataUrl     = BaseUrl + "model_quantized.onnx_data";

--- a/SentenceTransformers.Harrier.Medium/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Medium/src/SentenceEncoder.cs
@@ -94,11 +94,15 @@ namespace SentenceTransformers.Harrier.Medium
         /// <param name="modelUrl">URL for the .onnx graph file. Defaults to <see cref="DefaultModelUrl"/>.</param>
         /// <param name="modelDataUrl">URL for the accompanying .onnx_data weights file. Pass null to skip.
         /// Defaults to <see cref="DefaultModelDataUrl"/> when <paramref name="modelUrl"/> is also null.</param>
+        /// <param name="reportProgress">Optional progress callback. Receives a <see cref="DownloadProgress"/>
+        /// roughly twice per second per file. Multi-file downloads (graph + <c>.onnx_data</c>) invoke the
+        /// callback once per file; use <see cref="DownloadProgress.FileName"/> to tell them apart.</param>
         public static async Task<SentenceEncoder> CreateAsync(
             SessionOptions sessionOptions = null,
             string modelUrl = null,
             string modelDataUrl = null,
             string downloadToPath = null,
+            Action<DownloadProgress> reportProgress = null,
             CancellationToken cancellationToken = default)
         {
             var path = downloadToPath ?? Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Medium", "harrier-medium-model.onnx");
@@ -109,7 +113,7 @@ namespace SentenceTransformers.Harrier.Medium
             // If user left both null, use the default pair.
             var resolvedDataUrl = modelDataUrl ?? (modelUrl is null ? DefaultModelDataUrl : null);
 
-            await DownloadModelAsync(resolvedModelUrl, path, cancellationToken);
+            await DownloadModelAsync(resolvedModelUrl, path, reportProgress, cancellationToken);
             if (!string.IsNullOrEmpty(resolvedDataUrl))
             {
                 // ONNX runtime expects the external data file to live next to the .onnx file
@@ -118,7 +122,7 @@ namespace SentenceTransformers.Harrier.Medium
                 // that filename to keep the reference resolvable.
                 var dataFileName = Path.GetFileName(new Uri(resolvedDataUrl).LocalPath);
                 var dataPath = Path.Combine(Path.GetDirectoryName(path)!, dataFileName);
-                await DownloadModelAsync(resolvedDataUrl, dataPath, cancellationToken);
+                await DownloadModelAsync(resolvedDataUrl, dataPath, reportProgress, cancellationToken);
             }
             return new SentenceEncoder(sessionOptions, path);
         }
@@ -393,7 +397,9 @@ namespace SentenceTransformers.Harrier.Medium
         /// Only one download runs at a time. On failure, any partial file at <paramref name="localPath"/> is deleted.
         /// Re-used for both the .onnx graph and its accompanying .onnx_data file.
         /// </summary>
-        public static async Task DownloadModelAsync(string modelUrl, string localPath, CancellationToken cancellationToken = default)
+        /// <param name="reportProgress">Optional progress callback. Receives a <see cref="DownloadProgress"/>
+        /// at most twice per second while bytes are flowing. Set to <c>null</c> to skip reporting.</param>
+        public static async Task DownloadModelAsync(string modelUrl, string localPath, Action<DownloadProgress> reportProgress = null, CancellationToken cancellationToken = default)
         {
             if (File.Exists(localPath)) return;
 
@@ -407,6 +413,10 @@ namespace SentenceTransformers.Harrier.Medium
                 throw new ArgumentException("Local path must be non-empty.", nameof(localPath));
             }
 
+            var fileName = Path.GetFileName(localPath);
+            // Declared in the outer scope so the Report local function (below) can read it across
+            // the try block. Captured locally in the loop, refreshed when the response changes.
+            long? totalBytes = null;
 
             await _oneDownloadAtATime.WaitAsync(cancellationToken);
             try
@@ -417,10 +427,15 @@ namespace SentenceTransformers.Harrier.Medium
                 {
                     response.EnsureSuccessStatusCode();
                     var supportsRange = response.Headers.AcceptRanges.Contains("bytes");
+                    // Content-Length on the first response is the full size; on a ranged retry it's
+                    // the remaining bytes, so capture it here.
+                    totalBytes = response.Content.Headers.ContentLength;
 
                     await using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, buffer.Length, true);
                     var totalBytesRead = 0L;
                     var finished = false;
+                    var lastReportTicks = 0L;
+                    Report(0L); // initial 0% notification so callers can show "starting…"
 
                     while (!finished)
                     {
@@ -432,8 +447,16 @@ namespace SentenceTransformers.Harrier.Medium
                             {
                                 await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
                                 totalBytesRead += bytesRead;
+                                // Throttle progress callbacks to ~2 Hz so the consumer (UI / log) isn't flooded.
+                                var nowTicks = Environment.TickCount64;
+                                if (nowTicks - lastReportTicks >= 500)
+                                {
+                                    lastReportTicks = nowTicks;
+                                    Report(totalBytesRead);
+                                }
                             }
                             finished = true;
+                            Report(totalBytesRead); // final 100% notification
                         }
                         catch (Exception ex)
                         {
@@ -456,6 +479,12 @@ namespace SentenceTransformers.Harrier.Medium
                             response.Dispose();
                             response = await _downloadClient.SendAsync(newRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                             response.EnsureSuccessStatusCode();
+                            // Re-base the total from the new (possibly ranged) response: a ranged response
+                            // reports the remaining bytes in its Content-Length, so add what's already on disk.
+                            if (response.Content.Headers.ContentLength is long len)
+                            {
+                                totalBytes = totalBytesRead + len;
+                            }
                         }
                     }
                 }
@@ -472,6 +501,15 @@ namespace SentenceTransformers.Harrier.Medium
             finally
             {
                 _oneDownloadAtATime.Release();
+            }
+
+            void Report(long received)
+            {
+                if (reportProgress is null) return;
+                var fraction = totalBytes is long total && total > 0
+                    ? Math.Clamp(received / (float)total, 0f, 1f)
+                    : 0f;
+                reportProgress(new DownloadProgress(received, totalBytes, fraction, fileName));
             }
         }
     }

--- a/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
@@ -19,16 +19,17 @@ namespace SentenceTransformers.Harrier.Small
     {
         /// <summary>
         /// Default URL used to download the ONNX model when no path is provided.
-        /// Points to the standard quantized variant (~344 MB external data) which produces
-        /// float32 output and is the most broadly compatible with onnxruntime CPU/GPU providers.
+        /// Points to the Q4F16 variant (~172 MB external data), the smallest variant by disk
+        /// size for Harrier Small. Choose a different <see cref="Quantizations"/> entry when
+        /// you need higher precision or smaller graph latency.
         /// </summary>
-        public const string DefaultModelUrl = Quantizations.QuantizedModelUrl;
+        public const string DefaultModelUrl = Quantizations.Q4Fp16ModelUrl;
 
         /// <summary>
         /// Default URL for the external ONNX data file that accompanies <see cref="DefaultModelUrl"/>.
         /// Hugging Face splits Harrier ONNX models into a small graph file plus a separate weights file.
         /// </summary>
-        public const string DefaultModelDataUrl = Quantizations.QuantizedModelDataUrl;
+        public const string DefaultModelDataUrl = Quantizations.Q4Fp16ModelDataUrl;
 
         /// <summary>
         /// Download URLs for the Harrier Small (270m) ONNX model variants published by
@@ -57,12 +58,12 @@ namespace SentenceTransformers.Harrier.Small
             /// <summary>External weights for <see cref="Q4ModelUrl"/>.</summary>
             public const string Q4ModelDataUrl            = BaseUrl + "model_q4.onnx_data";
 
-            /// <summary>4-bit-with-FP16-residual graph (~172 MB external weights). Smallest variant.</summary>
+            /// <summary>4-bit-with-FP16-residual graph (~172 MB external weights). The default variant - smallest on disk.</summary>
             public const string Q4Fp16ModelUrl            = BaseUrl + "model_q4f16.onnx";
             /// <summary>External weights for <see cref="Q4Fp16ModelUrl"/>.</summary>
             public const string Q4Fp16ModelDataUrl        = BaseUrl + "model_q4f16.onnx_data";
 
-            /// <summary>Standard quantized graph (~344 MB external weights, fp32 output). The default variant.</summary>
+            /// <summary>Standard quantized graph (~344 MB external weights, fp32 output).</summary>
             public const string QuantizedModelUrl         = BaseUrl + "model_quantized.onnx";
             /// <summary>External weights for <see cref="QuantizedModelUrl"/>.</summary>
             public const string QuantizedModelDataUrl     = BaseUrl + "model_quantized.onnx_data";

--- a/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Small/src/SentenceEncoder.cs
@@ -92,11 +92,15 @@ namespace SentenceTransformers.Harrier.Small
         /// <param name="modelUrl">URL for the .onnx graph file. Defaults to <see cref="DefaultModelUrl"/>.</param>
         /// <param name="modelDataUrl">URL for the accompanying .onnx_data weights file. Pass null to skip.
         /// Defaults to <see cref="DefaultModelDataUrl"/> when <paramref name="modelUrl"/> is also null.</param>
+        /// <param name="reportProgress">Optional progress callback. Receives a <see cref="DownloadProgress"/>
+        /// roughly twice per second per file. Multi-file downloads (graph + <c>.onnx_data</c>) invoke the
+        /// callback once per file; use <see cref="DownloadProgress.FileName"/> to tell them apart.</param>
         public static async Task<SentenceEncoder> CreateAsync(
             SessionOptions sessionOptions = null,
             string modelUrl = null,
             string modelDataUrl = null,
             string downloadToPath = null,
+            Action<DownloadProgress> reportProgress = null,
             CancellationToken cancellationToken = default)
         {
             var path = downloadToPath ?? Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small", "harrier-small-model.onnx");
@@ -107,14 +111,14 @@ namespace SentenceTransformers.Harrier.Small
             // If user left both null, use the default pair.
             var resolvedDataUrl = modelDataUrl ?? (modelUrl is null ? DefaultModelDataUrl : null);
 
-            await DownloadModelAsync(resolvedModelUrl, path, cancellationToken);
+            await DownloadModelAsync(resolvedModelUrl, path, reportProgress, cancellationToken);
             if (!string.IsNullOrEmpty(resolvedDataUrl))
             {
                 // ONNX runtime expects the external data file to live next to the .onnx file
                 // with the exact name referenced in the model's external_data entry.
                 var dataFileName = Path.GetFileName(new Uri(resolvedDataUrl).LocalPath);
                 var dataPath = Path.Combine(Path.GetDirectoryName(path)!, dataFileName);
-                await DownloadModelAsync(resolvedDataUrl, dataPath, cancellationToken);
+                await DownloadModelAsync(resolvedDataUrl, dataPath, reportProgress, cancellationToken);
             }
             return new SentenceEncoder(sessionOptions, path);
         }
@@ -392,7 +396,9 @@ namespace SentenceTransformers.Harrier.Small
         /// Only one download runs at a time. On failure, any partial file at <paramref name="localPath"/> is deleted.
         /// Re-used for both the .onnx graph and its accompanying .onnx_data file.
         /// </summary>
-        public static async Task DownloadModelAsync(string modelUrl, string localPath, CancellationToken cancellationToken = default)
+        /// <param name="reportProgress">Optional progress callback. Receives a <see cref="DownloadProgress"/>
+        /// at most twice per second while bytes are flowing. Set to <c>null</c> to skip reporting.</param>
+        public static async Task DownloadModelAsync(string modelUrl, string localPath, Action<DownloadProgress> reportProgress = null, CancellationToken cancellationToken = default)
         {
             if (File.Exists(localPath)) return;
 
@@ -406,6 +412,10 @@ namespace SentenceTransformers.Harrier.Small
                 throw new ArgumentException("Local path must be non-empty.", nameof(localPath));
             }
 
+            var fileName = Path.GetFileName(localPath);
+            // Declared in the outer scope so the Report local function (below) can read it across
+            // the try block. Captured locally in the loop, refreshed when the response changes.
+            long? totalBytes = null;
 
             await _oneDownloadAtATime.WaitAsync(cancellationToken);
             try
@@ -416,10 +426,15 @@ namespace SentenceTransformers.Harrier.Small
                 {
                     response.EnsureSuccessStatusCode();
                     var supportsRange = response.Headers.AcceptRanges.Contains("bytes");
+                    // Content-Length on the first response is the full size; on a ranged retry it's
+                    // the remaining bytes, so capture it here.
+                    totalBytes = response.Content.Headers.ContentLength;
 
                     await using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, buffer.Length, true);
                     var totalBytesRead = 0L;
                     var finished = false;
+                    var lastReportTicks = 0L;
+                    Report(0L); // initial 0% notification so callers can show "starting…"
 
                     while (!finished)
                     {
@@ -431,8 +446,16 @@ namespace SentenceTransformers.Harrier.Small
                             {
                                 await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
                                 totalBytesRead += bytesRead;
+                                // Throttle progress callbacks to ~2 Hz so the consumer (UI / log) isn't flooded.
+                                var nowTicks = Environment.TickCount64;
+                                if (nowTicks - lastReportTicks >= 500)
+                                {
+                                    lastReportTicks = nowTicks;
+                                    Report(totalBytesRead);
+                                }
                             }
                             finished = true;
+                            Report(totalBytesRead); // final 100% notification
                         }
                         catch (Exception ex)
                         {
@@ -455,6 +478,12 @@ namespace SentenceTransformers.Harrier.Small
                             response.Dispose();
                             response = await _downloadClient.SendAsync(newRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                             response.EnsureSuccessStatusCode();
+                            // Re-base the total from the new (possibly ranged) response: a ranged response
+                            // reports the remaining bytes in its Content-Length, so add what's already on disk.
+                            if (response.Content.Headers.ContentLength is long len)
+                            {
+                                totalBytes = totalBytesRead + len;
+                            }
                         }
                     }
                 }
@@ -471,6 +500,15 @@ namespace SentenceTransformers.Harrier.Small
             finally
             {
                 _oneDownloadAtATime.Release();
+            }
+
+            void Report(long received)
+            {
+                if (reportProgress is null) return;
+                var fraction = totalBytes is long total && total > 0
+                    ? Math.Clamp(received / (float)total, 0f, 1f)
+                    : 0f;
+                reportProgress(new DownloadProgress(received, totalBytes, fraction, fileName));
             }
         }
     }

--- a/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Qwen3/src/SentenceEncoder.cs
@@ -40,15 +40,18 @@ namespace SentenceTransformers.Qwen3
         /// Downloads the model from <paramref name="modelUrl"/> to <paramref name="downloadToPath"/> (or a temp path if null),
         /// then creates an encoder from that path. Tokenizer is loaded from Resources/tokenizer.json or embedded resource.
         /// </summary>
+        /// <param name="reportProgress">Optional progress callback. Receives a <see cref="DownloadProgress"/>
+        /// roughly twice per second while the model is downloading.</param>
         public static async Task<SentenceEncoder> CreateAsync(
             SessionOptions sessionOptions = null,
             string modelUrl = null,
             string downloadToPath = null,
+            Action<DownloadProgress> reportProgress = null,
             CancellationToken cancellationToken = default)
         {
             var path = downloadToPath ?? Path.Combine(Path.GetTempPath(), "SentenceTransformers.Qwen3", "qwen3-model.onnx");
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            await DownloadModelAsync(modelUrl ?? DefaultModelUrl, path, cancellationToken);
+            await DownloadModelAsync(modelUrl ?? DefaultModelUrl, path, reportProgress, cancellationToken);
             return new SentenceEncoder(sessionOptions, path);
         }
 
@@ -310,7 +313,9 @@ namespace SentenceTransformers.Qwen3
         /// Downloads the ONNX model from <paramref name="modelUrl"/> to <paramref name="localPath"/>.
         /// Only one download runs at a time. On failure, any partial file at <paramref name="localPath"/> is deleted.
         /// </summary>
-        public static async Task DownloadModelAsync(string modelUrl, string localPath, CancellationToken cancellationToken = default)
+        /// <param name="reportProgress">Optional progress callback. Receives a <see cref="DownloadProgress"/>
+        /// at most twice per second while bytes are flowing. Set to <c>null</c> to skip reporting.</param>
+        public static async Task DownloadModelAsync(string modelUrl, string localPath, Action<DownloadProgress> reportProgress = null, CancellationToken cancellationToken = default)
         {
             if (File.Exists(localPath)) return;
 
@@ -324,6 +329,10 @@ namespace SentenceTransformers.Qwen3
                 throw new ArgumentException("Local path must be non-empty.", nameof(localPath));
             }
 
+            var fileName = Path.GetFileName(localPath);
+            // Declared in the outer scope so the Report local function (below) can read it across
+            // the try block. Refreshed when the response changes on a ranged retry.
+            long? totalBytes = null;
 
             await _oneDownloadAtATime.WaitAsync(cancellationToken);
             try
@@ -334,10 +343,13 @@ namespace SentenceTransformers.Qwen3
                 {
                     response.EnsureSuccessStatusCode();
                     var supportsRange = response.Headers.AcceptRanges.Contains("bytes");
+                    totalBytes = response.Content.Headers.ContentLength;
 
                     await using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, buffer.Length, true);
                     var totalBytesRead = 0L;
                     var finished = false;
+                    var lastReportTicks = 0L;
+                    Report(0L); // initial 0% notification so callers can show "starting…"
 
                     while (!finished)
                     {
@@ -349,8 +361,15 @@ namespace SentenceTransformers.Qwen3
                             {
                                 await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
                                 totalBytesRead += bytesRead;
+                                var nowTicks = Environment.TickCount64;
+                                if (nowTicks - lastReportTicks >= 500)
+                                {
+                                    lastReportTicks = nowTicks;
+                                    Report(totalBytesRead);
+                                }
                             }
                             finished = true;
+                            Report(totalBytesRead); // final 100% notification
                         }
                         catch (Exception ex)
                         {
@@ -373,6 +392,10 @@ namespace SentenceTransformers.Qwen3
                             response.Dispose();
                             response = await _downloadClient.SendAsync(newRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                             response.EnsureSuccessStatusCode();
+                            if (response.Content.Headers.ContentLength is long len)
+                            {
+                                totalBytes = totalBytesRead + len;
+                            }
                         }
                     }
                 }
@@ -381,7 +404,7 @@ namespace SentenceTransformers.Qwen3
                     response?.Dispose();
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 File.Delete(localPath);
                 throw;
@@ -389,6 +412,15 @@ namespace SentenceTransformers.Qwen3
             finally
             {
                 _oneDownloadAtATime.Release();
+            }
+
+            void Report(long received)
+            {
+                if (reportProgress is null) return;
+                var fraction = totalBytes is long total && total > 0
+                    ? Math.Clamp(received / (float)total, 0f, 1f)
+                    : 0f;
+                reportProgress(new DownloadProgress(received, totalBytes, fraction, fileName));
             }
         }
     }

--- a/SentenceTransformers/src/DownloadProgress.cs
+++ b/SentenceTransformers/src/DownloadProgress.cs
@@ -1,0 +1,12 @@
+namespace SentenceTransformers;
+
+/// <summary>
+/// Progress snapshot for an in-progress model download. Passed to the
+/// <c>reportProgress</c> callback on <c>SentenceEncoder.DownloadModelAsync</c> and
+/// <c>CreateAsync</c> a few times per second.
+/// </summary>
+/// <param name="DownloadedBytes">Total bytes received so far. Resumed downloads include the bytes already on disk.</param>
+/// <param name="TotalBytes">Total size in bytes from the response's <c>Content-Length</c> header, or <c>null</c> when the server didn't send one.</param>
+/// <param name="Fraction">Progress in <c>[0, 1]</c> when <see cref="TotalBytes"/> is known; <c>0</c> otherwise.</param>
+/// <param name="FileName">The on-disk filename being written (the final segment of <c>localPath</c>). Useful when a single logical model download spans multiple files (e.g. an ONNX graph plus its <c>.onnx_data</c>).</param>
+public sealed record DownloadProgress(long DownloadedBytes, long? TotalBytes, float Fraction, string FileName);


### PR DESCRIPTION
## Summary

- `DefaultModelUrl` / `DefaultModelDataUrl` on both `SentenceTransformers.Harrier.Medium` and `SentenceTransformers.Harrier.Small` now point at the **Q4F16** variant — the smallest on disk for each model (353 MB and 172 MB respectively, vs. 706 MB / 344 MB for the previous `Quantized` default). Multilingual retrieval quality stays near-identical to the unquantized reference (verified across all 5 quantizations in `HarrierVariantsTest`); callers who need the float32 graph or a different precision can still pick any `SentenceEncoder.Quantizations` entry explicitly.
- New `SentenceTransformers.DownloadProgress` record and an optional `Action<DownloadProgress> reportProgress` parameter on `DownloadModelAsync` / `CreateAsync` for `Qwen3`, `Harrier.Medium` and `Harrier.Small`. Throttled to ~2 Hz per file and reports `DownloadedBytes`, `TotalBytes` (nullable, from `Content-Length`), `Fraction` and `FileName` so multi-file downloads (graph + `.onnx_data`) can be distinguished.
- README quantization table updated to mark `Q4F16` as the default and rewritten the explanatory copy.
- README "Models" table gains NuGet download-count badges alongside each version badge, so all 6 published packages link to NuGet with both freshness and uptake signals.

## Test plan

- [x] `dotnet build SentenceTransformers.sln -c Debug`
- [x] `dotnet test SentenceTransformers.Tests` — 49/49 pass
- [x] All 5 Harrier.Medium and 5 Harrier.Small quantization variants previously verified end-to-end (cross-lingual similarities within ~0.005 of the unquantized reference)
- [ ] CI green

## Downstream

Mosaik's `EmbeddingModelDownloader` consumes the new progress callback to surface live download progress (transferred bytes, percent, current filename) in the AI Indexing settings page. That branch pins to `26.6.1600`, so once this PR merges and the pipeline publishes a `>= 1600` version, the Mosaik branch can be merged too.

https://claude.ai/code/session_01R6qwrDwSigbM238ngVnQxn