### PR TITLE
Add a private GlobalThreadPool and migrate Harrier.Small.Pure off Parallel.ForAsync

### DIFF
--- a/SentenceTransformers.Benchmark/HarrierDiag.cs
+++ b/SentenceTransformers.Benchmark/HarrierDiag.cs
@@ -1,0 +1,45 @@
+using SentenceTransformers.Harrier.Small.Pure;
+using SentenceTransformers.Harrier.Small.Pure.Model;
+
+public static class HarrierDiag
+{
+    public static async Task RunAsync()
+    {
+        using var enc = await SentenceEncoder.CreateAsync();
+
+        var queries = new[] { "how much protein should a female eat", "summit define" };
+        var documents = new[]
+        {
+            "As a general guideline, the CDC's average requirement of protein for women ages 19 to 70 is 46 grams per day. But, as you can see from this chart, you'll need to increase that if you're expecting or training for a marathon. Check out the chart below to see how much protein you should be eating each day.",
+            "Definition of summit for English Language Learners. : 1  the highest point of a mountain : the top of a mountain. : 2  the highest level. : 3  a meeting or series of meetings between the leaders of two or more governments.",
+        };
+
+        var q = await enc.EncodeQueriesAsync(queries, SentenceEncoder.Prompts.WebSearchQuery);
+        var d = await enc.EncodeAsync(documents);
+
+        float[,] expected = { { 64.57f, 25.45f }, { 29.97f, 67.41f } };
+        for (int i = 0; i < q.Length; i++)
+        {
+            for (int j = 0; j < d.Length; j++)
+            {
+                float dot = 0;
+                for (int k = 0; k < q[i].Length; k++) dot += q[i][k] * d[j][k];
+                float score = dot * 100f;
+                Console.WriteLine($"score[{i},{j}]={score:F2} expected {expected[i, j]:F2} diff={score - expected[i,j]:+0.00;-0.00}");
+            }
+        }
+
+        for (int i = 0; i < q.Length; i++)
+        {
+            float n = 0;
+            for (int k = 0; k < q[i].Length; k++) n += q[i][k] * q[i][k];
+            Console.WriteLine($"|q[{i}]|^2 = {n:F6}  first5=[{q[i][0]:F4},{q[i][1]:F4},{q[i][2]:F4},{q[i][3]:F4},{q[i][4]:F4}]");
+        }
+        for (int j = 0; j < d.Length; j++)
+        {
+            float n = 0;
+            for (int k = 0; k < d[j].Length; k++) n += d[j][k] * d[j][k];
+            Console.WriteLine($"|d[{j}]|^2 = {n:F6}  first5=[{d[j][0]:F4},{d[j][1]:F4},{d[j][2]:F4},{d[j][3]:F4},{d[j][4]:F4}]");
+        }
+    }
+}

--- a/SentenceTransformers.Benchmark/HarrierPureBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierPureBench.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using SentenceTransformers.Harrier.Small.Pure;
+using SentenceTransformers.Harrier.Small.Pure.Model;
+
+/// <summary>
+/// End-to-end timing for the Pure encoder on a short batch. Uses the cached weights at the standard
+/// path (see SentenceEncoder.CreateAsync), so it does not redownload on each invocation. Reports
+/// ms/iter for each quantization, which is the metric to watch for the parallelism migration: an
+/// encode is dominated by the per-layer matmul fork/joins now running on
+/// <see cref="SentenceTransformers.GlobalThreadPool"/>.
+/// </summary>
+public static class HarrierPureBench
+{
+    public static async Task RunAsync()
+    {
+        var texts = new[]
+        {
+            "Curiosity is the wick in the candle of learning.",
+            "Quantization shrinks weights and trades a little accuracy for a lot of memory.",
+            "Vector search retrieves the documents whose embedding is closest to the query's embedding.",
+            "The harrier small model is a decoder-only transformer with grouped-query attention.",
+        };
+
+        foreach (var quant in new[] { Quantization.None, Quantization.Int8, Quantization.Int4 })
+        {
+            using var enc = await SentenceEncoder.CreateAsync(quantization: quant);
+
+            // Warm up (downloads / quantizes happen here).
+            await enc.EncodeAsync(texts);
+            await enc.EncodeAsync(texts);
+
+            const int iterations = 5;
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                await enc.EncodeAsync(texts);
+            }
+            sw.Stop();
+
+            double ms = sw.Elapsed.TotalMilliseconds / iterations;
+            Console.WriteLine($"[Harrier.Small.Pure {quant}]");
+            Console.WriteLine($"  Batch:    {texts.Length}");
+            Console.WriteLine($"  Per iter: {ms,8:F1} ms");
+            Console.WriteLine($"  Throughput: {1000.0 * texts.Length / ms,6:F2} embeddings/s");
+        }
+    }
+}

--- a/SentenceTransformers.Benchmark/ParallelMicrobench.cs
+++ b/SentenceTransformers.Benchmark/ParallelMicrobench.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics;
+using System.Numerics.Tensors;
+using SentenceTransformers;
+
+/// <summary>
+/// Micro-benchmark that compares <see cref="Parallel.ForAsync"/> (the previous parallelism back-end
+/// used by the Pure inference kernels) against <see cref="GlobalThreadPool.ForAsync"/> (the new
+/// fixed-worker, contiguous-bucket pool). It runs the exact shape that dominates the Pure forward
+/// pass - parallel float dot products over the output channels of a row-major weight matrix - so the
+/// results are representative of a single matmul layer.
+/// </summary>
+public static class ParallelMicrobench
+{
+    public static void Run(int seq, int inDim, int outDim, int iterations, int warmup)
+    {
+        var rng = new Random(1234);
+        var x = new float[seq * inDim];
+        var w = new float[outDim * inDim];
+        var y = new float[seq * outDim];
+        for (int i = 0; i < x.Length; i++)
+        {
+            x[i] = (float)(rng.NextDouble() * 2 - 1);
+        }
+        for (int i = 0; i < w.Length; i++)
+        {
+            w[i] = (float)(rng.NextDouble() * 2 - 1);
+        }
+
+        // Warm up both paths.
+        for (int i = 0; i < warmup; i++)
+        {
+            ParallelForAsyncMatmul(x, w, y, seq, inDim, outDim).GetAwaiter().GetResult();
+            GlobalThreadPoolMatmul(x, w, y, seq, inDim, outDim).GetAwaiter().GetResult();
+        }
+
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+        {
+            ParallelForAsyncMatmul(x, w, y, seq, inDim, outDim).GetAwaiter().GetResult();
+        }
+        sw.Stop();
+        double parMs = sw.Elapsed.TotalMilliseconds / iterations;
+
+        sw.Restart();
+        for (int i = 0; i < iterations; i++)
+        {
+            GlobalThreadPoolMatmul(x, w, y, seq, inDim, outDim).GetAwaiter().GetResult();
+        }
+        sw.Stop();
+        double poolMs = sw.Elapsed.TotalMilliseconds / iterations;
+
+        Console.WriteLine($"[matmul seq={seq} inDim={inDim} outDim={outDim}, iters={iterations}]");
+        Console.WriteLine($"  Parallel.ForAsync   : {parMs,8:F3} ms/iter");
+        Console.WriteLine($"  GlobalThreadPool    : {poolMs,8:F3} ms/iter   ({parMs / poolMs:F2}x)");
+    }
+
+    private static Task ParallelForAsyncMatmul(float[] x, float[] w, float[] y, int seq, int inDim, int outDim)
+    {
+        return Parallel.ForAsync(0, outDim, (o, _) =>
+        {
+            LinearColumn(x, w, y, seq, inDim, outDim, o);
+            return ValueTask.CompletedTask;
+        });
+    }
+
+    private static Task GlobalThreadPoolMatmul(float[] x, float[] w, float[] y, int seq, int inDim, int outDim)
+    {
+        return GlobalThreadPool.ForAsync(0, outDim, (x, w, y, seq, inDim, outDim), static (start, end, st) =>
+        {
+            for (int o = start; o < end; o++)
+            {
+                LinearColumn(st.x, st.w, st.y, st.seq, st.inDim, st.outDim, o);
+            }
+        });
+    }
+
+    private static void LinearColumn(float[] x, float[] w, float[] y, int seq, int inDim, int outDim, int o)
+    {
+        var wRow = new ReadOnlySpan<float>(w, o * inDim, inDim);
+        for (int s = 0; s < seq; s++)
+        {
+            y[s * outDim + o] = TensorPrimitives.Dot(new ReadOnlySpan<float>(x, s * inDim, inDim), wRow);
+        }
+    }
+}

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -19,6 +19,12 @@ if (args.Length > 0 && args[0] == "harrier-pure-bench")
     return;
 }
 
+if (args.Length > 0 && args[0] == "harrier-diag")
+{
+    await HarrierDiag.RunAsync();
+    return;
+}
+
 // ---- Build a few-paragraph input dataset ----
 var texts = new[]
 {

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -2,6 +2,22 @@ using System.Diagnostics;
 using System.Text;
 using SentenceTransformers;
 
+if (args.Length > 0 && args[0] == "parallel-bench")
+{
+    Console.WriteLine($"Workers: {GlobalThreadPool.WorkerCount} (Environment.ProcessorCount={Environment.ProcessorCount})");
+    Console.WriteLine();
+    ParallelMicrobench.Run(seq:  64, inDim:  640, outDim: 2048, iterations: 200, warmup: 20);
+    ParallelMicrobench.Run(seq:  64, inDim: 2048, outDim:  640, iterations: 200, warmup: 20);
+    ParallelMicrobench.Run(seq: 128, inDim:  640, outDim:  640, iterations: 200, warmup: 20);
+    ParallelMicrobench.Run(seq: 256, inDim:  640, outDim:  128, iterations: 200, warmup: 20);
+    return;
+}
+
+if (args.Length > 0 && args[0] == "harrier-pure-bench")
+{
+    await HarrierPureBench.RunAsync();
+    return;
+}
 
 // ---- Build a few-paragraph input dataset ----
 var texts = new[]

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Numerics.Tensors;
+using SentenceTransformers;
 using SentenceTransformers.Harrier.Small.Pure.Numerics;
 
 namespace SentenceTransformers.Harrier.Small.Pure.Model;
@@ -72,8 +73,8 @@ internal sealed class Gemma3Model
         var embed = st.ReadRaw16(prefix + "embed_tokens.weight");
 
         // The attention/MLP projections dominate weight size and compute, so they carry the chosen
-        // quantization (built on Parallel.ForAsync, never blocking); the tiny per-channel norm vectors
-        // stay in float32.
+        // quantization (built on the GlobalThreadPool, never blocking); the tiny per-channel norm
+        // vectors stay in float32.
         Task<IWeightMatrix> Proj(string p, string name, int outDim, int inDim)
             => IWeightMatrix.CreateAsync(st.ReadFloat(p + name), outDim, inDim, quantization, ct);
 
@@ -113,9 +114,9 @@ internal sealed class Gemma3Model
 
     /// <summary>Runs the full forward pass for one tokenized sequence and returns the (un-normalized)
     /// last-token hidden state - a <c>HiddenSize</c>-length embedding. The per-layer matmuls and
-    /// attention parallelize with <c>Parallel.ForAsync</c>, so the heavy CPU work is awaited rather than
-    /// blocking the caller, and <paramref name="ct"/> cancels in-flight compute. Takes <c>int[]</c>
-    /// (not a span) because async methods cannot have ref-struct parameters.</summary>
+    /// attention parallelize on the <see cref="GlobalThreadPool"/>, so the heavy CPU work is awaited
+    /// rather than blocking the caller, and <paramref name="ct"/> cancels in-flight compute. Takes
+    /// <c>int[]</c> (not a span) because async methods cannot have ref-struct parameters.</summary>
     public async Task<float[]> ForwardAsync(int[] tokenIds, CancellationToken ct)
     {
         int seq = tokenIds.Length;
@@ -251,19 +252,22 @@ internal sealed class Gemma3Model
     }
 
     /// <summary>Causal grouped-query attention. The single KV head is shared by all query heads.
-    /// Parallelizes over query positions; per-index <c>Parallel.ForAsync</c> dispatch gives dynamic load
-    /// balancing for the triangular causal work and does not block the awaiting thread.</summary>
+    /// Parallelizes over query positions on the <see cref="GlobalThreadPool"/>: each worker gets a
+    /// contiguous bucket of query positions, so the body runs once per bucket instead of once per
+    /// position and the dispatch is fork/join only (no per-row task wake-up).</summary>
     private Task AttentionAsync(float[] q, float[] k, float[] v, float[] attnOut, int seq, int headDim, CancellationToken ct)
     {
         int qStride = _cfg.NumHeads * headDim;
         int kvStride = _cfg.NumKvHeads * headDim; // == headDim (1 KV head)
         int heads = _cfg.NumHeads;
         float scale = _cfg.AttentionScale;
-        return Parallel.ForAsync(0, seq, ct, (i, _) =>
+        return GlobalThreadPool.ForAsync(0, seq, (q, k, v, attnOut, headDim, qStride, kvStride, heads, scale), static (start, end, st) =>
         {
-            AttentionRow(q, k, v, attnOut, i, headDim, qStride, kvStride, heads, scale);
-            return ValueTask.CompletedTask;
-        });
+            for (int i = start; i < end; i++)
+            {
+                AttentionRow(st.q, st.k, st.v, st.attnOut, i, st.headDim, st.qStride, st.kvStride, st.heads, st.scale);
+            }
+        }, ct);
     }
 
     /// <summary>Computes attention output for one query position across all heads. Synchronous so the

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Weights.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Weights.cs
@@ -3,6 +3,7 @@ using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using SentenceTransformers;
 
 namespace SentenceTransformers.Harrier.Small.Pure.Model;
 
@@ -109,14 +110,14 @@ internal interface IWeightMatrix
     int InDim { get; }
     int OutDim { get; }
 
-    /// <summary>Multiplies a batch of activations, parallelizing over output channels with
-    /// <c>Parallel.ForAsync</c> so the (CPU-heavy) work does not block the awaiting thread and honours
-    /// <paramref name="ct"/>.</summary>
+    /// <summary>Multiplies a batch of activations, parallelizing over output channels on the
+    /// <see cref="GlobalThreadPool"/> so the (CPU-heavy) work does not block the awaiting thread and
+    /// honours <paramref name="ct"/>.</summary>
     ValueTask MultiplyAsync(float[] x, float[] y, int seq, CancellationToken ct);
 
     /// <summary>Builds the weight matrix for the chosen precision. For the quantized variants the
-    /// (CPU-heavy) quantization runs on <c>Parallel.ForAsync</c> so it does not block a thread-pool
-    /// thread when awaited from the async load path.</summary>
+    /// (CPU-heavy) quantization runs on the <see cref="GlobalThreadPool"/> so it does not block a
+    /// thread-pool thread when awaited from the async load path.</summary>
     static async Task<IWeightMatrix> CreateAsync(float[] weights, int outDim, int inDim, Quantization quantization, CancellationToken ct)
     {
         switch (quantization)
@@ -146,11 +147,13 @@ internal static class VnniActivations
         int qmax = Vnni.QMax;
         try
         {
-            await Parallel.ForAsync(0, seq, ct, (s, _) =>
+            await GlobalThreadPool.ForAsync(0, seq, (x, ua, scale, inDim, zp, qmax), static (start, end, st) =>
             {
-                QuantizeRow(x, ua, scale, s, inDim, zp, qmax);
-                return ValueTask.CompletedTask;
-            }).ConfigureAwait(false);
+                for (int s = start; s < end; s++)
+                {
+                    QuantizeRow(st.x, st.ua, st.scale, s, st.inDim, st.zp, st.qmax);
+                }
+            }, ct).ConfigureAwait(false);
         }
         catch
         {
@@ -230,27 +233,29 @@ internal sealed class Int8Matrix : IWeightMatrix
         var q = new sbyte[(long)outDim * inDim <= int.MaxValue ? outDim * inDim : throw new OverflowException()];
         var scale = new float[outDim];
         var rowSum = new int[outDim];
-        await Parallel.ForAsync(0, outDim, ct, (o, _) =>
+        await GlobalThreadPool.ForAsync(0, outDim, (w, q, scale, rowSum, inDim), static (start, end, st) =>
         {
-            int baseIdx = o * inDim;
-            float amax = 0f;
-            for (int i = 0; i < inDim; i++)
+            for (int o = start; o < end; o++)
             {
-                amax = MathF.Max(amax, MathF.Abs(w[baseIdx + i]));
+                int baseIdx = o * st.inDim;
+                float amax = 0f;
+                for (int i = 0; i < st.inDim; i++)
+                {
+                    amax = MathF.Max(amax, MathF.Abs(st.w[baseIdx + i]));
+                }
+                float s = amax > 0 ? amax / 127f : 1f;
+                float inv = 1f / s;
+                st.scale[o] = s;
+                int sum = 0;
+                for (int i = 0; i < st.inDim; i++)
+                {
+                    int v = Math.Clamp((int)MathF.Round(st.w[baseIdx + i] * inv), -127, 127);
+                    st.q[baseIdx + i] = (sbyte)v;
+                    sum += v;
+                }
+                st.rowSum[o] = sum;
             }
-            float s = amax > 0 ? amax / 127f : 1f;
-            float inv = 1f / s;
-            scale[o] = s;
-            int sum = 0;
-            for (int i = 0; i < inDim; i++)
-            {
-                int v = Math.Clamp((int)MathF.Round(w[baseIdx + i] * inv), -127, 127);
-                q[baseIdx + i] = (sbyte)v;
-                sum += v;
-            }
-            rowSum[o] = sum;
-            return ValueTask.CompletedTask;
-        }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
         return new Int8Matrix(q, scale, rowSum, outDim, inDim);
     }
 
@@ -273,29 +278,31 @@ internal sealed class Int8Matrix : IWeightMatrix
         {
             bool use512 = Vnni.Use512 && (inDim % 64 == 0);
             int oTiles = (outDim + 3) / 4;
-            await Parallel.ForAsync(0, oTiles, ct, (ot, _) =>
+            await GlobalThreadPool.ForAsync(0, oTiles, (self: this, ua, aScale, y, seq, inDim, outDim, use512), static (start, end, st) =>
             {
-                int o0 = ot * 4;
-                if (o0 + 4 <= outDim)
+                for (int ot = start; ot < end; ot++)
                 {
-                    if (use512)
+                    int o0 = ot * 4;
+                    if (o0 + 4 <= st.outDim)
                     {
-                        Tile4_512(ua, aScale, y, o0, seq, inDim, outDim);
+                        if (st.use512)
+                        {
+                            st.self.Tile4_512(st.ua, st.aScale, st.y, o0, st.seq, st.inDim, st.outDim);
+                        }
+                        else
+                        {
+                            st.self.Tile4(st.ua, st.aScale, st.y, o0, st.seq, st.inDim, st.outDim);
+                        }
                     }
                     else
                     {
-                        Tile4(ua, aScale, y, o0, seq, inDim, outDim);
+                        for (int o = o0; o < st.outDim; o++)
+                        {
+                            st.self.SingleChannel(st.ua, st.aScale, st.y, o, st.seq, st.inDim, st.outDim);
+                        }
                     }
                 }
-                else
-                {
-                    for (int o = o0; o < outDim; o++)
-                    {
-                        SingleChannel(ua, aScale, y, o, seq, inDim, outDim);
-                    }
-                }
-                return ValueTask.CompletedTask;
-            }).ConfigureAwait(false);
+            }, ct).ConfigureAwait(false);
         }
         finally
         {
@@ -469,11 +476,13 @@ internal sealed class Int8Matrix : IWeightMatrix
     private ValueTask MultiplyFloatAsync(float[] x, float[] y, int seq, CancellationToken ct)
     {
         int inDim = InDim, outDim = OutDim;
-        return new ValueTask(Parallel.ForAsync(0, outDim, ct, (o, _) =>
+        return new ValueTask(GlobalThreadPool.ForAsync(0, outDim, (self: this, x, y, seq, inDim, outDim), static (start, end, st) =>
         {
-            FloatColumn(x, y, seq, inDim, outDim, o);
-            return ValueTask.CompletedTask;
-        }));
+            for (int o = start; o < end; o++)
+            {
+                st.self.FloatColumn(st.x, st.y, st.seq, st.inDim, st.outDim, o);
+            }
+        }, ct));
     }
 
     // Separate sync method so the stackalloc/Span does not live inside a (forbidden) async body.
@@ -542,42 +551,44 @@ internal sealed class Int4Matrix : IWeightMatrix
         var scale = new float[outDim * numGroups];
         var groupSum = new int[outDim * numGroups];
 
-        await Parallel.ForAsync(0, outDim, ct, (o, _) =>
+        await GlobalThreadPool.ForAsync(0, outDim, (w, packed, scale, groupSum, numGroups, inDim), static (start, end, st) =>
         {
-            int rowBase = o * inDim;
-            for (int g = 0; g < numGroups; g++)
+            for (int o = start; o < end; o++)
             {
-                int gStart = g * GroupSize;
-                float amax = 0f;
-                for (int i = 0; i < GroupSize; i++)
+                int rowBase = o * st.inDim;
+                for (int g = 0; g < st.numGroups; g++)
                 {
-                    amax = MathF.Max(amax, MathF.Abs(w[rowBase + gStart + i]));
-                }
-                // Symmetric int4 in [-7, 7]; reserve nibble 0..15 = q + 8.
-                float s = amax > 0 ? amax / 7f : 1f;
-                float inv = 1f / s;
-                scale[o * numGroups + g] = s;
-                int sum = 0;
-                for (int i = 0; i < GroupSize; i++)
-                {
-                    int idx = rowBase + gStart + i;
-                    int q = Math.Clamp((int)MathF.Round(w[idx] * inv), -7, 7);
-                    sum += q;
-                    int nibble = q + 8; // 1..15
-                    int packIdx = idx >> 1;
-                    if ((idx & 1) == 0)
+                    int gStart = g * GroupSize;
+                    float amax = 0f;
+                    for (int i = 0; i < GroupSize; i++)
                     {
-                        packed[packIdx] = (byte)((packed[packIdx] & 0xF0) | (nibble & 0x0F));
+                        amax = MathF.Max(amax, MathF.Abs(st.w[rowBase + gStart + i]));
                     }
-                    else
+                    // Symmetric int4 in [-7, 7]; reserve nibble 0..15 = q + 8.
+                    float s = amax > 0 ? amax / 7f : 1f;
+                    float inv = 1f / s;
+                    st.scale[o * st.numGroups + g] = s;
+                    int sum = 0;
+                    for (int i = 0; i < GroupSize; i++)
                     {
-                        packed[packIdx] = (byte)((packed[packIdx] & 0x0F) | (nibble << 4));
+                        int idx = rowBase + gStart + i;
+                        int q = Math.Clamp((int)MathF.Round(st.w[idx] * inv), -7, 7);
+                        sum += q;
+                        int nibble = q + 8; // 1..15
+                        int packIdx = idx >> 1;
+                        if ((idx & 1) == 0)
+                        {
+                            st.packed[packIdx] = (byte)((st.packed[packIdx] & 0xF0) | (nibble & 0x0F));
+                        }
+                        else
+                        {
+                            st.packed[packIdx] = (byte)((st.packed[packIdx] & 0x0F) | (nibble << 4));
+                        }
                     }
+                    st.groupSum[o * st.numGroups + g] = sum;
                 }
-                groupSum[o * numGroups + g] = sum;
             }
-            return ValueTask.CompletedTask;
-        }).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
         return new Int4Matrix(packed, scale, groupSum, numGroups, outDim, inDim);
     }
 
@@ -590,11 +601,13 @@ internal sealed class Int4Matrix : IWeightMatrix
         var (ua, aScale) = await VnniActivations.QuantizeAsync(x, seq, inDim, ct).ConfigureAwait(false);
         try
         {
-            await Parallel.ForAsync(0, outDim, ct, (o, _) =>
+            await GlobalThreadPool.ForAsync(0, outDim, (self: this, ua, aScale, y, seq, inDim, outDim), static (start, end, st) =>
             {
-                VnniColumn(ua, aScale, y, o, seq, inDim, outDim);
-                return ValueTask.CompletedTask;
-            }).ConfigureAwait(false);
+                for (int o = start; o < end; o++)
+                {
+                    st.self.VnniColumn(st.ua, st.aScale, st.y, o, st.seq, st.inDim, st.outDim);
+                }
+            }, ct).ConfigureAwait(false);
         }
         finally
         {
@@ -637,11 +650,13 @@ internal sealed class Int4Matrix : IWeightMatrix
     private ValueTask MultiplyFloatAsync(float[] x, float[] y, int seq, CancellationToken ct)
     {
         int inDim = InDim, outDim = OutDim;
-        return new ValueTask(Parallel.ForAsync(0, outDim, ct, (o, _) =>
+        return new ValueTask(GlobalThreadPool.ForAsync(0, outDim, (self: this, x, y, seq, inDim, outDim), static (start, end, st) =>
         {
-            FloatColumn(x, y, seq, inDim, outDim, o);
-            return ValueTask.CompletedTask;
-        }));
+            for (int o = start; o < end; o++)
+            {
+                st.self.FloatColumn(st.x, st.y, st.seq, st.inDim, st.outDim, o);
+            }
+        }, ct));
     }
 
     private void FloatColumn(float[] x, float[] y, int seq, int inDim, int outDim, int o)

--- a/SentenceTransformers.Harrier.Small.Pure/src/Numerics/Ops.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Numerics/Ops.cs
@@ -1,5 +1,6 @@
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
+using SentenceTransformers;
 
 namespace SentenceTransformers.Harrier.Small.Pure.Numerics;
 
@@ -19,8 +20,9 @@ internal static class Ops
     /// Row-major linear projection without bias: <c>y[s, o] = sum_i x[s, i] * w[o, i]</c>.
     /// This matches PyTorch's <c>nn.Linear</c> weight layout <c>[outDim, inDim]</c>, so each output
     /// channel's weights are contiguous and feed straight into a SIMD dot product. Parallelized over
-    /// the output channels (via <see cref="Parallel.ForAsync(int, int, CancellationToken, Func{int, CancellationToken, ValueTask})"/>,
-    /// so the heavy work does not block the awaiting thread) for anything but the smallest matrices.
+    /// the output channels via <see cref="GlobalThreadPool.ForAsync"/> (a contiguous bucket of output
+    /// channels per worker, body as a <c>static</c> lambda with no closure allocation) for anything
+    /// but the smallest matrices.
     /// </summary>
     /// <param name="x">Input activations, length <c>seq * inDim</c>.</param>
     /// <param name="w">Weight matrix, length <c>outDim * inDim</c>, row-major <c>[outDim, inDim]</c>.</param>
@@ -35,11 +37,13 @@ internal static class Ops
             }
             return Task.CompletedTask;
         }
-        return Parallel.ForAsync(0, outDim, ct, (o, _) =>
+        return GlobalThreadPool.ForAsync(0, outDim, (x, w, y, seq, inDim, outDim), static (start, end, s) =>
         {
-            LinearColumn(x, w, y, seq, inDim, outDim, o);
-            return ValueTask.CompletedTask;
-        });
+            for (int o = start; o < end; o++)
+            {
+                LinearColumn(s.x, s.w, s.y, s.seq, s.inDim, s.outDim, o);
+            }
+        }, ct);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/SentenceTransformers/src/GlobalThreadPool.cs
+++ b/SentenceTransformers/src/GlobalThreadPool.cs
@@ -1,0 +1,243 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace SentenceTransformers;
+
+/// <summary>
+/// A long-lived, process-wide thread pool dedicated to the CPU-heavy fork/join work that the
+/// pure-managed inference kernels do (matmuls, attention, quantization). It is intentionally separate
+/// from the .NET <see cref="ThreadPool"/>: those threads are shared with arbitrary library code and are
+/// scheduled with a hill-climbing throughput heuristic that interacts badly with the short, fully
+/// CPU-bound bursts a forward pass produces. Here the worker count is fixed (by default
+/// <see cref="Environment.ProcessorCount"/>), every thread is pinned to
+/// <see cref="ThreadPriority.Highest"/> and stays alive for the lifetime of the process, so a parallel
+/// fork takes only the wake-up of N already-running threads.
+///
+/// The <see cref="ForAsync{T}"/> primitive splits <c>[fromInclusive, toExclusive)</c> into one
+/// contiguous bucket per worker; the body runs once per bucket and iterates the range itself. The
+/// caller-provided state of type <typeparamref name="T"/> is a value type, which lets the body be a
+/// <c>static</c> lambda (no closure allocations, no display class) - exactly the shape that a hot
+/// matmul loop needs.
+///
+/// Dispatch is intentionally tight: a single <see cref="SemaphoreSlim.Release(int)"/> wakes N workers
+/// in one call, each worker does a short spin before parking so back-to-back forks (the common case
+/// for a forward pass) keep the cache hot, and the per-call object graph is two allocations - the job
+/// (which is itself the <see cref="System.Threading.Tasks.TaskCompletionSource"/>) plus the body
+/// delegate.
+/// </summary>
+public static class GlobalThreadPool
+{
+    private static readonly Lock _initLock = new();
+    private static volatile bool _initialized;
+    private static int _workerCount;
+    private static readonly ConcurrentQueue<Action> _queue = new();
+    private static readonly SemaphoreSlim _hasWork = new(0);
+
+    /// <summary>The number of worker threads in the pool. Initializes the pool with the defaults
+    /// (<see cref="Environment.ProcessorCount"/>, <see cref="ThreadPriority.Highest"/>) on first read
+    /// when <see cref="Initialize"/> was not called explicitly.</summary>
+    public static int WorkerCount
+    {
+        get
+        {
+            EnsureInitialized();
+            return _workerCount;
+        }
+    }
+
+    /// <summary>Configures the pool. Must be called before any work is dispatched (i.e. before the
+    /// first <see cref="ForAsync{T}"/> call); subsequent calls are no-ops and return false. If the
+    /// pool is used without an explicit call it is auto-initialized with
+    /// <see cref="Environment.ProcessorCount"/> threads at <see cref="ThreadPriority.Highest"/>.</summary>
+    /// <param name="threadCount">Number of worker threads. Clamped to at least 1.</param>
+    /// <param name="priority">OS thread priority for every worker.</param>
+    /// <returns>True if this call initialized the pool; false if it was already initialized.</returns>
+    public static bool Initialize(int threadCount, ThreadPriority priority)
+    {
+        if (_initialized)
+        {
+            return false;
+        }
+        lock (_initLock)
+        {
+            if (_initialized)
+            {
+                return false;
+            }
+            int n = Math.Max(1, threadCount);
+            _workerCount = n;
+            _initialized = true;
+            for (int i = 0; i < n; i++)
+            {
+                var t = new Thread(WorkerLoop)
+                {
+                    IsBackground = true,
+                    Name = $"SentenceTransformers.GlobalThreadPool[{i}]",
+                    Priority = priority,
+                };
+                t.Start();
+            }
+            return true;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void EnsureInitialized()
+    {
+        if (!_initialized)
+        {
+            Initialize(Environment.ProcessorCount, ThreadPriority.Highest);
+        }
+    }
+
+    private static void WorkerLoop()
+    {
+        // Short spin before parking: forward-pass forks come in rapid bursts (multiple matmuls per
+        // layer x layers), so a bounded spin keeps cache hot and avoids a kernel wakeup for the
+        // common case where the next dispatch arrives within microseconds. The budget is intentionally
+        // tiny - SpinWait switches to Sleep(1) past ~10 iterations on .NET, so 30 is enough to cover
+        // the gap between back-to-back dispatches without pinning a core.
+        const int spinIterations = 30;
+        while (true)
+        {
+            if (_queue.TryDequeue(out var work))
+            {
+                work();
+                continue;
+            }
+            var spin = new SpinWait();
+            while (_queue.IsEmpty && spin.Count < spinIterations)
+            {
+                spin.SpinOnce(sleep1Threshold: -1);
+            }
+            if (!_queue.IsEmpty)
+            {
+                continue;
+            }
+            _hasWork.Wait();
+        }
+    }
+
+    /// <summary>
+    /// Parallel for-loop over <c>[fromInclusive, toExclusive)</c>: the range is split into
+    /// <see cref="WorkerCount"/> (or fewer, for tiny ranges) contiguous buckets and dispatched across
+    /// the worker threads. The returned <see cref="Task"/> completes once every bucket has finished;
+    /// if any bucket throws, the first observed exception is propagated and the others are dropped.
+    ///
+    /// The body is invoked once per bucket with the half-open <c>[start, end)</c> range, plus the
+    /// caller's <typeparamref name="T"/> state - so callers pass any data the body needs in the state
+    /// struct and write the body as a <c>static</c> lambda, avoiding the closure/display-class
+    /// allocations the equivalent <see cref="Parallel.ForAsync(int, int, CancellationToken, Func{int, CancellationToken, ValueTask})"/>
+    /// per-index lambda would require.
+    /// </summary>
+    /// <typeparam name="T">Value type carrying any data the body needs. <see cref="ValueTuple"/> is
+    /// the usual choice.</typeparam>
+    /// <param name="fromInclusive">Lower bound of the iteration range.</param>
+    /// <param name="toExclusive">Exclusive upper bound of the iteration range.</param>
+    /// <param name="state">Value passed to every bucket invocation of <paramref name="body"/>.</param>
+    /// <param name="body">Bucket body. Receives <c>(start, endExclusive, state)</c>.</param>
+    /// <param name="ct">Cancellation token. Already-running buckets run to completion; not-yet-started
+    /// buckets are skipped and the returned task transitions to <see cref="TaskStatus.Canceled"/>.</param>
+    public static Task ForAsync<T>(int fromInclusive, int toExclusive, T state, Action<int, int, T> body, CancellationToken ct = default)
+        where T : struct
+    {
+        if (body is null)
+        {
+            throw new ArgumentNullException(nameof(body));
+        }
+        if (ct.IsCancellationRequested)
+        {
+            return Task.FromCanceled(ct);
+        }
+        int total = toExclusive - fromInclusive;
+        if (total <= 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        EnsureInitialized();
+
+        int workers = Math.Min(_workerCount, total);
+        var ctx = new ForContext<T>(workers, state, body, ct, fromInclusive, total);
+        // One delegate allocation (method group) reused by every worker; each worker atomically
+        // claims its bucket index and computes the contiguous range from it. All buckets but one go
+        // to the pool; the caller runs the last bucket inline - the calling thread is about to await
+        // this Task anyway, so spending it on real work (instead of one queue-dispatch + thread
+        // wake-up) is free, and the caller often gets to return synchronously when its bucket happens
+        // to be the last one to finish.
+        int dispatched = workers - 1;
+        if (dispatched > 0)
+        {
+            Action runner = ctx.RunNextBucket;
+            for (int w = 0; w < dispatched; w++)
+            {
+                _queue.Enqueue(runner);
+            }
+            _hasWork.Release(dispatched);
+        }
+        ctx.RunNextBucket();
+        return ctx.Task;
+    }
+
+    // The job state and its completion source share one allocation: ForContext _is_ the
+    // TaskCompletionSource the caller awaits.
+    private sealed class ForContext<T> : TaskCompletionSource where T : struct
+    {
+        private readonly Action<int, int, T> _body;
+        private readonly T _state;
+        private readonly CancellationToken _ct;
+        private readonly int _from;
+        private readonly int _baseSize;
+        private readonly int _remainder;
+        private int _nextBucket = -1;
+        private int _remaining;
+        private Exception _error;
+
+        public ForContext(int workers, T state, Action<int, int, T> body, CancellationToken ct, int from, int total)
+            : base(TaskCreationOptions.RunContinuationsAsynchronously)
+        {
+            _remaining = workers;
+            _state = state;
+            _body = body;
+            _ct = ct;
+            _from = from;
+            _baseSize = total / workers;
+            _remainder = total % workers;
+        }
+
+        public void RunNextBucket()
+        {
+            int idx = Interlocked.Increment(ref _nextBucket);
+            int start = _from + idx * _baseSize + Math.Min(idx, _remainder);
+            int end = start + _baseSize + (idx < _remainder ? 1 : 0);
+            try
+            {
+                if (!_ct.IsCancellationRequested && Volatile.Read(ref _error) is null)
+                {
+                    _body(start, end, _state);
+                }
+            }
+            catch (Exception e)
+            {
+                Interlocked.CompareExchange(ref _error, e, null);
+            }
+
+            if (Interlocked.Decrement(ref _remaining) == 0)
+            {
+                var err = _error;
+                if (err is not null)
+                {
+                    SetException(err);
+                }
+                else if (_ct.IsCancellationRequested)
+                {
+                    SetCanceled(_ct);
+                }
+                else
+                {
+                    SetResult();
+                }
+            }
+        }
+    }
+}

--- a/SentenceTransformers/src/GlobalThreadPool.cs
+++ b/SentenceTransformers/src/GlobalThreadPool.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
 namespace SentenceTransformers;
@@ -10,8 +9,7 @@ namespace SentenceTransformers;
 /// scheduled with a hill-climbing throughput heuristic that interacts badly with the short, fully
 /// CPU-bound bursts a forward pass produces. Here the worker count is fixed (by default
 /// <see cref="Environment.ProcessorCount"/>), every thread is pinned to
-/// <see cref="ThreadPriority.Highest"/> and stays alive for the lifetime of the process, so a parallel
-/// fork takes only the wake-up of N already-running threads.
+/// <see cref="ThreadPriority.Highest"/> and stays alive for the lifetime of the process.
 ///
 /// The <see cref="ForAsync{T}"/> primitive splits <c>[fromInclusive, toExclusive)</c> into one
 /// contiguous bucket per worker; the body runs once per bucket and iterates the range itself. The
@@ -19,19 +17,26 @@ namespace SentenceTransformers;
 /// <c>static</c> lambda (no closure allocations, no display class) - exactly the shape that a hot
 /// matmul loop needs.
 ///
-/// Dispatch is intentionally tight: a single <see cref="SemaphoreSlim.Release(int)"/> wakes N workers
-/// in one call, each worker does a short spin before parking so back-to-back forks (the common case
-/// for a forward pass) keep the cache hot, and the per-call object graph is two allocations - the job
-/// (which is itself the <see cref="System.Threading.Tasks.TaskCompletionSource"/>) plus the body
-/// delegate.
+/// Dispatch is contention-free in the bucket dimension: every bucket is pre-computed and written
+/// directly to a target worker's private mailbox before that worker is signalled. There is no shared
+/// work queue, no per-bucket atomic claim, no per-worker scratch on the job - each worker reads
+/// <c>{ job, start, end }</c> from its own mailbox and writes nothing the other workers will read.
+/// The only shared state the job carries is a single completion counter that each bucket decrements
+/// once at the end, plus the first-exception slot. Workers come from / return to a free-worker stack;
+/// in the steady state of one producer at a time (a forward pass's sequential awaited matmuls) the
+/// stack sees no contention either, and the pool's only remaining lock briefly serializes the (N-1)
+/// finishers of a dispatch as they re-enter the free stack.
 /// </summary>
 public static class GlobalThreadPool
 {
     private static readonly Lock _initLock = new();
     private static volatile bool _initialized;
     private static int _workerCount;
-    private static readonly ConcurrentQueue<Action> _queue = new();
-    private static readonly SemaphoreSlim _hasWork = new(0);
+    private static Worker[] _workers;
+
+    // Free-worker stack. Guarded by its own lock; only briefly held (push or pop of a few refs).
+    private static readonly Lock _freeLock = new();
+    private static readonly Stack<Worker> _free = new();
 
     /// <summary>The number of worker threads in the pool. Initializes the pool with the defaults
     /// (<see cref="Environment.ProcessorCount"/>, <see cref="ThreadPriority.Highest"/>) on first read
@@ -65,17 +70,23 @@ public static class GlobalThreadPool
                 return false;
             }
             int n = Math.Max(1, threadCount);
+            var workers = new Worker[n];
+            for (int i = 0; i < n; i++)
+            {
+                workers[i] = new Worker(i);
+            }
+            _workers = workers;
             _workerCount = n;
+            // Push all workers onto the free stack before starting threads so the first ForAsync
+            // call after Initialize finds a full stack.
+            for (int i = 0; i < n; i++)
+            {
+                _free.Push(workers[i]);
+            }
             _initialized = true;
             for (int i = 0; i < n; i++)
             {
-                var t = new Thread(WorkerLoop)
-                {
-                    IsBackground = true,
-                    Name = $"SentenceTransformers.GlobalThreadPool[{i}]",
-                    Priority = priority,
-                };
-                t.Start();
+                workers[i].Start(priority);
             }
             return true;
         }
@@ -90,34 +101,6 @@ public static class GlobalThreadPool
         }
     }
 
-    private static void WorkerLoop()
-    {
-        // Short spin before parking: forward-pass forks come in rapid bursts (multiple matmuls per
-        // layer x layers), so a bounded spin keeps cache hot and avoids a kernel wakeup for the
-        // common case where the next dispatch arrives within microseconds. The budget is intentionally
-        // tiny - SpinWait switches to Sleep(1) past ~10 iterations on .NET, so 30 is enough to cover
-        // the gap between back-to-back dispatches without pinning a core.
-        const int spinIterations = 30;
-        while (true)
-        {
-            if (_queue.TryDequeue(out var work))
-            {
-                work();
-                continue;
-            }
-            var spin = new SpinWait();
-            while (_queue.IsEmpty && spin.Count < spinIterations)
-            {
-                spin.SpinOnce(sleep1Threshold: -1);
-            }
-            if (!_queue.IsEmpty)
-            {
-                continue;
-            }
-            _hasWork.Wait();
-        }
-    }
-
     /// <summary>
     /// Parallel for-loop over <c>[fromInclusive, toExclusive)</c>: the range is split into
     /// <see cref="WorkerCount"/> (or fewer, for tiny ranges) contiguous buckets and dispatched across
@@ -129,6 +112,10 @@ public static class GlobalThreadPool
     /// struct and write the body as a <c>static</c> lambda, avoiding the closure/display-class
     /// allocations the equivalent <see cref="Parallel.ForAsync(int, int, CancellationToken, Func{int, CancellationToken, ValueTask})"/>
     /// per-index lambda would require.
+    ///
+    /// All bucket boundaries are computed up front and written to each worker's private mailbox - no
+    /// per-bucket atomic claim, no shared work queue. The caller runs the last (smallest) bucket
+    /// inline; the dispatched buckets are 0..buckets-2.
     /// </summary>
     /// <typeparam name="T">Value type carrying any data the body needs. <see cref="ValueTuple"/> is
     /// the usual choice.</typeparam>
@@ -157,59 +144,101 @@ public static class GlobalThreadPool
 
         EnsureInitialized();
 
-        int workers = Math.Min(_workerCount, total);
-        var ctx = new ForContext<T>(workers, state, body, ct, fromInclusive, total);
-        // One delegate allocation (method group) reused by every worker; each worker atomically
-        // claims its bucket index and computes the contiguous range from it. All buckets but one go
-        // to the pool; the caller runs the last bucket inline - the calling thread is about to await
-        // this Task anyway, so spending it on real work (instead of one queue-dispatch + thread
-        // wake-up) is free, and the caller often gets to return synchronously when its bucket happens
-        // to be the last one to finish.
-        int dispatched = workers - 1;
-        if (dispatched > 0)
+        int buckets = Math.Min(_workerCount, total);
+        int baseSize = total / buckets;
+        int remainder = total % buckets;
+        // First `remainder` buckets get one extra element; bucket index `buckets-1` is therefore the
+        // smallest (when remainder > 0), which is what the caller runs inline.
+        int dispatch = buckets - 1;
+
+        var job = new Job<T>(buckets, state, body, ct);
+
+        if (dispatch > 0)
         {
-            Action runner = ctx.RunNextBucket;
-            for (int w = 0; w < dispatched; w++)
+            // Pop up to `dispatch` workers under a brief lock. If the stack is short of workers
+            // (concurrent dispatchers, rare in our use case), the overflow buckets run inline below
+            // - safe but degrades parallelism for that one dispatch.
+            int got;
+            Worker[] taken;
+            lock (_freeLock)
             {
-                _queue.Enqueue(runner);
+                got = Math.Min(dispatch, _free.Count);
+                taken = got == 0 ? Array.Empty<Worker>() : new Worker[got];
+                for (int i = 0; i < got; i++)
+                {
+                    taken[i] = _free.Pop();
+                }
             }
-            _hasWork.Release(dispatched);
+
+            for (int i = 0; i < got; i++)
+            {
+                int start = fromInclusive + i * baseSize + Math.Min(i, remainder);
+                int end = start + baseSize + (i < remainder ? 1 : 0);
+                taken[i].Assign(job, start, end);
+            }
+
+            // Buckets we could not dispatch because the free stack was short: run them inline on the
+            // caller thread (in addition to the caller's normal inline bucket below). For the common
+            // case of one producer at a time this branch never fires.
+            for (int i = got; i < dispatch; i++)
+            {
+                int start = fromInclusive + i * baseSize + Math.Min(i, remainder);
+                int end = start + baseSize + (i < remainder ? 1 : 0);
+                job.RunBucket(start, end);
+            }
         }
-        ctx.RunNextBucket();
-        return ctx.Task;
+
+        // Caller runs the last (smallest) bucket inline - it is about to await this Task anyway, so
+        // spending its thread on real work (instead of one mailbox-write + thread wake-up) is free.
+        {
+            int i = buckets - 1;
+            int start = fromInclusive + i * baseSize + Math.Min(i, remainder);
+            int end = start + baseSize + (i < remainder ? 1 : 0);
+            job.RunBucket(start, end);
+        }
+
+        return job.Task;
     }
 
-    // The job state and its completion source share one allocation: ForContext _is_ the
-    // TaskCompletionSource the caller awaits.
-    private sealed class ForContext<T> : TaskCompletionSource where T : struct
+    private static void ReturnToFree(Worker w)
+    {
+        lock (_freeLock)
+        {
+            _free.Push(w);
+        }
+    }
+
+    /// <summary>Non-generic façade so a <see cref="Worker"/> can hold an <c>IBucketJob</c> reference
+    /// without knowing the closed <c>T</c> at the Job site.</summary>
+    private interface IBucketJob
+    {
+        void RunBucket(int start, int end);
+    }
+
+    /// <summary>The job state and its completion source share one allocation: Job _is_ the
+    /// TaskCompletionSource the caller awaits. The only fields workers race on are <c>_remaining</c>
+    /// (one decrement per bucket; the last one completes the task) and <c>_error</c> (first writer
+    /// wins). Bucket boundaries are passed to <see cref="RunBucket"/> directly - there is no shared
+    /// bucket counter for workers to contend on.</summary>
+    private sealed class Job<T> : TaskCompletionSource, IBucketJob where T : struct
     {
         private readonly Action<int, int, T> _body;
         private readonly T _state;
         private readonly CancellationToken _ct;
-        private readonly int _from;
-        private readonly int _baseSize;
-        private readonly int _remainder;
-        private int _nextBucket = -1;
         private int _remaining;
         private Exception _error;
 
-        public ForContext(int workers, T state, Action<int, int, T> body, CancellationToken ct, int from, int total)
+        public Job(int buckets, T state, Action<int, int, T> body, CancellationToken ct)
             : base(TaskCreationOptions.RunContinuationsAsynchronously)
         {
-            _remaining = workers;
+            _remaining = buckets;
             _state = state;
             _body = body;
             _ct = ct;
-            _from = from;
-            _baseSize = total / workers;
-            _remainder = total % workers;
         }
 
-        public void RunNextBucket()
+        public void RunBucket(int start, int end)
         {
-            int idx = Interlocked.Increment(ref _nextBucket);
-            int start = _from + idx * _baseSize + Math.Min(idx, _remainder);
-            int end = start + _baseSize + (idx < _remainder ? 1 : 0);
             try
             {
                 if (!_ct.IsCancellationRequested && Volatile.Read(ref _error) is null)
@@ -236,6 +265,68 @@ public static class GlobalThreadPool
                 else
                 {
                     SetResult();
+                }
+            }
+        }
+    }
+
+    /// <summary>One pool thread plus its private mailbox. A worker only ever reads its own mailbox
+    /// fields, and the dispatcher only ever writes the mailbox of workers it has popped off the free
+    /// stack - so once the dispatcher's <see cref="Assign"/> returns the worker races on no
+    /// shared mutable state for the duration of the body call.</summary>
+    private sealed class Worker
+    {
+        // Initial 0, no max - we never expect more than one outstanding Release before the worker
+        // Waits, but leaving the max unbounded avoids any chance of SemaphoreFullException from a
+        // race we missed.
+        private readonly SemaphoreSlim _signal = new(0);
+
+        // Mailbox. Written by the dispatcher inside Assign (under happens-before of Release), read
+        // by the worker after Wait (under happens-before of Wait's acquire fence). Plain fields are
+        // safe under that ordering.
+        private IBucketJob _job;
+        private int _start;
+        private int _end;
+
+        public Worker(int id) { Id = id; }
+        public int Id { get; }
+
+        public void Start(ThreadPriority priority)
+        {
+            var t = new Thread(Loop)
+            {
+                IsBackground = true,
+                Name = $"SentenceTransformers.GlobalThreadPool[{Id}]",
+                Priority = priority,
+            };
+            t.Start();
+        }
+
+        public void Assign(IBucketJob job, int start, int end)
+        {
+            _job = job;
+            _start = start;
+            _end = end;
+            _signal.Release();
+        }
+
+        private void Loop()
+        {
+            while (true)
+            {
+                _signal.Wait();
+                var job = _job;
+                int start = _start;
+                int end = _end;
+                _job = null;
+
+                try
+                {
+                    job.RunBucket(start, end);
+                }
+                finally
+                {
+                    ReturnToFree(this);
                 }
             }
         }


### PR DESCRIPTION
A fixed-size, high-priority thread pool (defaults to Environment.ProcessorCount
threads at ThreadPriority.Highest, configurable via GlobalThreadPool.Initialize)
backs a new ForAsync<T> primitive that splits the iteration range into one
contiguous bucket per worker and invokes the body once per bucket. The body
takes a generic struct state, so callers can write it as a static lambda with
no captured variables - the hot matmul/attention loops now dispatch with the
body delegate cached as a method group instead of allocating a per-iteration
closure.

Every Parallel.ForAsync call in Harrier.Small.Pure (Ops.LinearAsync,
Gemma3Model.AttentionAsync, and the five Weights.cs sites covering int8/int4
quantization and the float/VNNI matmul kernels) is migrated to the new pool.