### PR TITLE
Harrier Small: token-count scalability study + attention optimizations + multi-model sweep

### DIFF
--- a/SentenceTransformers.Benchmark.Sweep/Program.cs
+++ b/SentenceTransformers.Benchmark.Sweep/Program.cs
@@ -128,7 +128,10 @@ foreach (var model in models)
 
 PrintTable(rows);
 
-var outPath = "/tmp/harrier_model_sweep.json";
+// Unique per-filter path so a per-model driver (each model in its own process, to isolate OS OOM-kills
+// of the 0.6B models at long contexts) does not overwrite other models' results.
+var slug = filter is null ? "all" : new string(filter.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+var outPath = $"/tmp/sweep_{slug}.json";
 await File.WriteAllTextAsync(outPath, JsonSerializer.Serialize(rows, new JsonSerializerOptions { WriteIndented = true }));
 Console.WriteLine();
 Console.WriteLine($"Wrote {outPath}");

--- a/SentenceTransformers.Benchmark.Sweep/Program.cs
+++ b/SentenceTransformers.Benchmark.Sweep/Program.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using BERTTokenizers.Base;
+using SentenceTransformers;
+
+// Token-count scalability sweep across every available sentence-encoder model. For each model it sweeps
+// from 128 tokens up to that model's own context-window limit (powers of two), encodes a single input of
+// each length on all cores, and reports time taken plus input/output throughput in MB/s (à la the
+// SentenceTransformers.Benchmark project). Run:
+//
+//   dotnet run -c Release --project SentenceTransformers.Benchmark.Sweep
+//   dotnet run -c Release --project SentenceTransformers.Benchmark.Sweep -- harrier    # substring filter
+//
+// Pure-managed encoders are constructed with a max-core default ParallelOptions so EncodeAsync uses every
+// core; ONNX Runtime already does. Inputs are generated to a target word count and the actual (possibly
+// truncated) token count is measured and reported.
+
+var filter = args.Length > 0 ? args[0] : null;
+int[] targets = { 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768 };
+var maxCore = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount };
+
+Console.WriteLine($"Sentence-encoder token-count sweep (ProcessorCount={Environment.ProcessorCount})");
+Console.WriteLine($"Per model: 128 tokens up to the model's context window. Times + MB/s, single encode, all cores.");
+Console.WriteLine();
+
+var models = new List<ModelDef>
+{
+    new("MiniLM-L6-v2 (ONNX)", () =>
+    {
+        var e = new SentenceTransformers.MiniLM.SentenceEncoder();
+        return Task.FromResult(new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e));
+    }),
+    new("ArcticXs (ONNX)", () =>
+    {
+        var e = new SentenceTransformers.ArcticXs.SentenceEncoder();
+        return Task.FromResult(new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e));
+    }),
+    new("Qwen3-0.6B (ONNX)", async () =>
+    {
+        var e = await SentenceTransformers.Qwen3.SentenceEncoder.CreateAsync();
+        return new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e);
+    }),
+    new("Harrier.Small.Pure fp32", async () =>
+    {
+        var e = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
+            quantization: SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None, parallelOptions: maxCore);
+        return new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e);
+    }),
+    new("Harrier.Small.Pure Int8", async () =>
+    {
+        var e = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
+            quantization: SentenceTransformers.Harrier.Small.Pure.Model.Quantization.Int8, parallelOptions: maxCore);
+        return new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e);
+    }),
+    new("Harrier.Small ONNX Q4F16", async () =>
+    {
+        var e = await SentenceTransformers.Harrier.Small.SentenceEncoder.CreateAsync();
+        return new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e);
+    }),
+    new("Harrier.Small ONNX Int8", async () =>
+    {
+        var e = await SentenceTransformers.Harrier.Small.SentenceEncoder.CreateAsync(
+            modelUrl: SentenceTransformers.Harrier.Small.SentenceEncoder.Quantizations.QuantizedModelUrl,
+            modelDataUrl: SentenceTransformers.Harrier.Small.SentenceEncoder.Quantizations.QuantizedModelDataUrl,
+            downloadToPath: Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small.Int8", "model.onnx"));
+        return new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e);
+    }),
+    new("Harrier.Medium ONNX Q4F16", async () =>
+    {
+        var e = await SentenceTransformers.Harrier.Medium.SentenceEncoder.CreateAsync();
+        return new Runner(s => e.EncodeAsync(s), e.Tokenizer, e.MaxChunkLength, e);
+    }),
+};
+
+var rows = new List<Row>();
+
+foreach (var model in models)
+{
+    if (filter is not null && !model.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+    {
+        continue;
+    }
+
+    Console.WriteLine($"=== {model.Name} ===");
+    try
+    {
+        var r = await model.Create();
+        using (r.Disposable)
+        {
+            int CountTokens(string s) => r.Tokenizer.Encode(new[] { s })[0].InputIds.Length;
+
+            foreach (var target in targets)
+            {
+                if (target > r.MaxTokens) break; // past this model's context window
+
+                // Generate ~target words; ratio is ~1 token/word for these tokenizers, and the encoder
+                // truncates at the context window, so the measured token count lands near the target.
+                var text = string.Join(' ', Enumerable.Range(0, target).Select(Pool.Word));
+                int tokens = Math.Min(CountTokens(text), r.MaxTokens);
+                long inBytes = Encoding.UTF8.GetByteCount(text);
+
+                try
+                {
+                    var (ms, dim) = await TimeEncodeAsync(r.Encode, text, tokens);
+                    double sec = ms / 1000.0;
+                    double inMBs = inBytes / 1024.0 / 1024.0 / sec;
+                    double outMBs = (long)dim * sizeof(float) / 1024.0 / 1024.0 / sec;
+                    double tokPerSec = tokens / sec;
+                    rows.Add(new Row(model.Name, tokens, dim, ms, inMBs, outMBs, tokPerSec));
+                    Console.WriteLine($"  {tokens,6} tok: {ms,10:n1} ms | {inMBs,7:n3} MB/s in | {outMBs,7:n3} MB/s out | {tokPerSec,8:n1} tok/s");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"  {tokens,6} tok: failed ({ex.GetType().Name}: {ex.Message.Split('\n')[0]})");
+                }
+            }
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"  skipped ({ex.GetType().Name}: {ex.Message.Split('\n')[0]})");
+    }
+    Console.WriteLine();
+    GC.Collect();
+    GC.WaitForPendingFinalizers();
+}
+
+PrintTable(rows);
+
+var outPath = "/tmp/harrier_model_sweep.json";
+await File.WriteAllTextAsync(outPath, JsonSerializer.Serialize(rows, new JsonSerializerOptions { WriteIndented = true }));
+Console.WriteLine();
+Console.WriteLine($"Wrote {outPath}");
+
+
+// -------------------- helpers --------------------
+
+static async Task<(double Ms, int Dim)> TimeEncodeAsync(Func<string[], Task<float[][]>> encode, string text, int tokens)
+{
+    var batch = new[] { text };
+
+    // Warm up only for the cheaper points; an O(n^2) encode at 16k-32k tokens is minutes long.
+    if (tokens <= 2048)
+    {
+        await encode(batch);
+    }
+
+    int iterations =
+        tokens <= 256  ? 5 :
+        tokens <= 1024 ? 3 :
+        tokens <= 2048 ? 2 : 1;
+
+    int dim = 0;
+    var samples = new double[iterations];
+    for (int i = 0; i < iterations; i++)
+    {
+        var sw = Stopwatch.StartNew();
+        var emb = await encode(batch);
+        sw.Stop();
+        samples[i] = sw.Elapsed.TotalMilliseconds;
+        dim = emb.Length > 0 ? emb[0].Length : 0;
+    }
+    Array.Sort(samples);
+    return (samples[samples.Length / 2], dim);
+}
+
+static void PrintTable(List<Row> rows)
+{
+    if (rows.Count == 0) return;
+
+    int nameW = Math.Max(24, rows.Max(r => r.Model.Length));
+    Console.WriteLine("=== Results (single encode, all cores) ===");
+    Console.WriteLine($"{"Model".PadRight(nameW)} | {"Tokens",7} | {"Dim",5} | {"ms",10} | {"MB/s in",8} | {"MB/s out",8} | {"tok/s",9}");
+    Console.WriteLine(new string('-', nameW + 64));
+    foreach (var r in rows)
+    {
+        Console.WriteLine($"{r.Model.PadRight(nameW)} | {r.Tokens,7} | {r.Dim,5} | {r.Ms,10:n1} | {r.InMBs,8:n3} | {r.OutMBs,8:n3} | {r.TokPerSec,9:n1}");
+    }
+}
+
+internal sealed record ModelDef(string Name, Func<Task<Runner>> Create);
+
+internal sealed record Runner(
+    Func<string[], Task<float[][]>> Encode,
+    TokenizerBase                   Tokenizer,
+    int                             MaxTokens,
+    IDisposable                     Disposable);
+
+internal sealed record Row(string Model, int Tokens, int Dim, double Ms, double InMBs, double OutMBs, double TokPerSec);
+
+internal static class Pool
+{
+    private static readonly string[] _words =
+    {
+        "curiosity", "mosaik", "search", "embedding", "vector", "database", "ranking", "hybrid",
+        "context", "token", "runtime", "inference", "latency", "throughput", "quantization",
+        "semantic", "retrieval", "document", "chunk", "pipeline", "provider", "benchmark",
+        "scalability", "transformer", "attention", "encoder", "multilingual", "normalize",
+    };
+
+    public static string Word(int i) => _words[i % _words.Length];
+}

--- a/SentenceTransformers.Benchmark.Sweep/SentenceTransformers.Benchmark.Sweep.csproj
+++ b/SentenceTransformers.Benchmark.Sweep/SentenceTransformers.Benchmark.Sweep.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.24.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SentenceTransformers\SentenceTransformers.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.MiniLM\SentenceTransformers.MiniLM.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.ArcticXs\SentenceTransformers.ArcticXs.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Qwen3\SentenceTransformers.Qwen3.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier.Small\SentenceTransformers.Harrier.Small.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier.Small.Pure\SentenceTransformers.Harrier.Small.Pure.csproj" />
+    <ProjectReference Include="..\SentenceTransformers.Harrier.Medium\SentenceTransformers.Harrier.Medium.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SentenceTransformers.Benchmark/HARRIER-SCALING.md
+++ b/SentenceTransformers.Benchmark/HARRIER-SCALING.md
@@ -1,136 +1,101 @@
-# Harrier Small — token-count scalability
+# Harrier Small — token-count scalability & pure-vs-ONNX optimization
 
-Elapsed time per single-sentence encode for the `harrier-oss-v1-270m` model, swept across sequence
-lengths from 128 to 4096 tokens, for four implementations of the same model.
+Per-encode latency for `harrier-oss-v1-270m` swept over sequence length, comparing the pure-C#
+implementation (fp32 and Int8) against the ONNX Runtime builds (Q4F16 and Int8). All paths are driven
+with byte-identical calibrated inputs (one per target length, exact token count via the shared Gemma
+tokenizer) through the public `EncodeAsync` path. **All numbers below are on all 4 cores** — the pure
+encoder is driven with `ParallelOptions { MaxDegreeOfParallelism = ProcessorCount }` (the library default
+stays single-threaded; only the benchmark opts in) so the comparison reflects architecture, not core count.
 
-All were driven with **byte-identical calibrated input strings** (generated once and replayed from
-`/tmp/harrier_scaling_inputs.json`), each calibrated to land on an exact token count (incl.
-`<bos>`/`<eos>`) using the shared Gemma BPE tokenizer. Token counts matched exactly across all paths.
+Environment: 4-core CPU, 15 GiB RAM, .NET 10 Release; ONNX Runtime 1.24.2; pure fp32/Int8;
+ONNX Q4F16 (`model_q4f16`) and Int8 (`model_quantized`, `MatMulNBits` + fused `GroupQueryAttention`).
 
-## Environment
+> Precision note: pure-fp32 and ONNX differ in weight precision (Int8 / Q4F16). The apples-to-apples
+> rows for the optimization work are **Pure Int8 vs ONNX Int8**.
 
-| | |
-|---|---|
-| CPU | 4 cores (CPU-only, no GPU) |
-| RAM | 15 GiB |
-| Pure C# | `SentenceTransformers.Harrier.Small.Pure`, .NET 10, Release, fp32 and Int8 |
-| ONNX C# | `SentenceTransformers.Harrier.Small`, ONNX Runtime 1.24.2, **Q4F16** (package default) |
-| Python | `sentence-transformers` 5.5.1 / `transformers` 5.12.0 / torch 2.12.0, CPU, fp32 |
-| Method | warmup encode, then median of N iters (7/5/3/2/1 as length grows) |
+## Results — ms per encode (all on max cores)
 
-> **Important threading caveat.** The pure columns below were produced by the public document
-> `EncodeAsync(string[])` path, which builds a default `ParallelOptions` (`MaxDegreeOfParallelism == -1`).
-> `ParallelExecution.ForAsync` only fans out when `MaxDegreeOfParallelism > 1`, and `-1` is *not* `> 1`,
-> so **the pure encoder ran single-threaded on 1 of 4 cores**, while ONNX and PyTorch used all 4.
-> Re-running the pure path with an explicit `MaxDegreeOfParallelism = 4` is **3.2–3.7× faster** (see the
-> profile section). The numbers below reflect each path's *shipping default*, which is itself a finding.
->
-> This is also **not** a same-precision comparison: Pure-fp32 and Python are fp32; Pure-Int8 is weight+
-> activation int8 (projections only); ONNX is Q4F16. See `int8` notes below.
+| Tokens | Pure fp32 | Pure Int8 | ONNX Q4F16 | ONNX Int8 | Pure Int8 / ONNX Int8 |
+|-------:|----------:|----------:|-----------:|----------:|----------------------:|
+|    128 |     652.9 |   **197.2** |      125.8 |     209.2 | **0.94× (pure wins)** |
+|    256 |   1,381.3 |     367.8 |      255.9 |     297.6 | 1.24× |
+|    512 |   2,947.4 |     809.2 |      529.5 |     508.2 | 1.59× |
+|  1,024 |   6,472.7 |   1,885.0 |    1,227.1 |   1,018.7 | 1.85× |
+|  2,048 |  13,866.9 |   4,909.3 |    3,236.7 |   2,767.5 | 1.77× |
+|  4,096 |  34,663.2 |  13,735.5 |    8,778.4 |   7,367.6 | 1.86× |
 
-## Results — elapsed ms per encode
+Short contexts (≤256 tokens) are at or beyond ONNX-Int8 parity; the residual gap at long contexts is
+entirely attention (below).
 
-| Tokens | Pure fp32 (1 core) | Pure Int8 (1 core) | Python fp32 (4 core) | ONNX Q4F16 (4 core) |
-|-------:|-------------------:|-------------------:|---------------------:|--------------------:|
-|    128 |            1,778.4 |              670.8 |                349.9 |               117.4 |
-|    256 |            3,838.4 |            1,406.9 |                589.5 |               287.1 |
-|    512 |            8,053.9 |            3,310.2 |              1,092.8 |               587.5 |
-|  1,024 |           18,819.7 |            8,688.6 |              2,166.8 |             1,178.2 |
-|  2,048 |           46,789.5 |           27,208.7 |              4,293.7 |             2,740.6 |
-|  4,096 |          120,825.7 |           85,162.8 |              9,571.8 |             7,105.0 |
+## What was optimized (and the journey)
 
-## Throughput — tokens/second (higher is better)
+Profiling the pure Int8 forward (per-stage, 4 cores) found two dominant costs and several dead ends.
 
-| Tokens | Pure fp32 | Pure Int8 | Python fp32 | ONNX Q4F16 |
-|-------:|----------:|----------:|------------:|-----------:|
-|    128 |        72 |       191 |         366 |      1,090 |
-|    256 |        67 |       182 |         434 |        892 |
-|    512 |        64 |       155 |         469 |        872 |
-|  1,024 |        54 |       118 |         473 |        869 |
-|  2,048 |        44 |        75 |         477 |        747 |
-|  4,096 |        34 |        48 |         428 |        577 |
+### 1. GeGLU — the big systemic win (committed)
+The feed-forward GeGLU was a **scalar serial loop calling `MathF.Tanh` per element** (~151M tanh calls
+at 4096 tokens). It was **40% of the time at 512 tokens** and ~4.5 s at 4096. Rewritten as a row-parallel,
+vectorized kernel (`TensorPrimitives` incl. vectorized tanh):
 
-## How each scales (128 → 4096, i.e. 32× more tokens)
+| GeGLU stage (Int8, 4 cores) | 512 tok | 4096 tok |
+|---|--:|--:|
+| before (scalar) | 604 ms | 4,483 ms |
+| after (vectorized) | 24 ms | 165 ms |
 
-| | growth | note |
-|---|---:|---|
-| Pure fp32 | **68×** | super-linear: O(n²) attention term grows in |
-| Pure Int8 | **127×** | *worse* ratio — Int8 shrinks only the linear projections, so the unquantized fp32 attention dominates faster |
-| ONNX Q4F16 | **61×** | super-linear |
-| Python fp32 | **27×** | ~300 ms fixed per-call floor dilutes the ratio |
+≈25× on that stage; this is what pulls short/medium contexts to parity.
 
-Int8 is 2.6× faster than fp32 at 128 tokens but only **1.4× faster at 4096** — direct evidence that
-quantization helps the projections but **not attention**, which is fp32 in both.
+### 2. Attention — the O(n²) scalability term
+Several kernels were implemented and measured (all gated by a `verify-fma` correctness check: fp32 stays
+cos = 1.0 vs the reference path, Int8 cos ≈ 0.998 — within the expected quantization tolerance):
 
-## Where the time goes — per-stage profile of the pure fp32 forward
+| attention kernel (Int8, 4 cores, 4096 tok) | attention ms | verdict |
+|---|--:|---|
+| original naive per-(query,head) dot | ~10,500 | baseline |
+| cache-blocked + 4-head-fused (bit-identical) | ~10,486 | ~same (memory-bound) |
+| FMA register-tiled (4×2 score GEMM) | ~10,545 | no gain → **compute is not the limit** |
+| naive online-softmax flash | ~28,000 (2048: 5,000) | **worse** — scalar `exp` ≫ vectorized exp |
+| **head-fused block-flash (chosen)** | **8,661** | **best** |
 
-Captured with the opt-in `ForwardProfile` (`harrier-profile <maxDop>`). Stopwatch/lock overhead inflates
-the absolute totals ~20–40 % vs the clean benchmark, but the proportions and the DOP speed-ups are
-accurate.
+The winning kernel (`FlashAttentionBlock`) combines every lever: it streams keys in L1-sized chunks with
+an **online softmax** (no seq×seq score matrix materialized — that buffer's traffic was the bottleneck),
+keeps a **large query block** so each K/V chunk is reused across many queries, **fuses the 4 GQA query
+heads** into one SIMD pass per key (`ScoreHeads4`/`AxpyHeads4`), and keeps `exp` **vectorized** by
+applying it per chunk. This mirrors ONNX's fused `GroupQueryAttention`.
 
-**Single-threaded (MaxDop=1):**
+Per-stage Int8 profile (4 cores), final kernels:
 
-| Stage | 512 tok | 2048 tok | 4096 tok |
+| Stage | 512 | 2048 | 4096 |
 |---|--:|--:|--:|
-| projections — mlp (gate/up/down) | 60.9% | 49.9% | 41.3% |
-| projections — qkv | 14.8% | 12.0% | 8.8% |
-| projections — o | 10.1% | 7.8% | 6.4% |
-| **attention (Q·Kᵀ, softmax, ·V)** | **8.5%** | **26.3%** | **40.5%** |
-| geglu | 4.9% | 3.5% | 2.6% |
-| norms + residual + rope | 0.8% | 0.6% | 0.4% |
-| total (ms) | 11,189 | 62,515 | 167,661 |
+| attention | 201 | 2,315 | 8,661 |
+| mlp_proj (Int8 VNNI) | 441 | 1,644 | 3,204 |
+| qkv+o (Int8 VNNI) | 263 | 781 | 1,479 |
+| geglu | 24 | 84 | 165 |
+| norms+rope | 122 | 413 | 811 |
 
-**Multi-threaded (MaxDop=4) total ms:** 512 → 3,532 (**3.2×**), 2048 → 17,530 (**3.6×**), 4096 → 45,417 (**3.7×**).
+### Net effect (Pure Int8 @ 4096, this box)
+single-threaded original **85,163 ms** → max cores + vectorized GeGLU + head-fused block-flash
+**13,735 ms** — **6.2× faster**.
 
-Takeaways from the profile:
-1. At short/medium lengths the bottleneck is the **fp32 projection matmuls (~85 % at 512)**, *not*
-   attention. Attention only becomes co-dominant at 4096 (40 %). This is why Int8 (which has tiled
-   VNNI kernels for the projections) gives a big win at short lengths.
-2. The pure path leaves **3.2–3.7× on the table** by defaulting to single-threaded in the document
-   `EncodeAsync` path.
-3. `geglu`, `rmsnorm`, `rope`, `headnorm` are **serial** loops (not parallelized), so their relative
-   share grows under MaxDop=4 (geglu 4.9 % → 15.9 % at 512).
+## Honest parity assessment
+- **Short/medium contexts (≤~256 tokens): parity reached** — pure Int8 (197 ms @128) actually beats
+  ONNX Int8 (209 ms), and is competitive to ~512.
+- **Long contexts: ~1.9× off at 4096**, and the gap is essentially all attention. The pure attention is
+  ~18 GFLOP/s/core; ONNX (MLAS-backed `GroupQueryAttention`) is ~2.5× higher. Closing the rest needs
+  either an MLAS-class packed/blocked fp32 GEMM microkernel or **int8/VNNI attention matmuls** (4× less
+  K/V memory traffic + VNNI throughput) — the remaining lever, with a small extra accuracy cost.
 
-## Why pure is slower than PyTorch/ONNX — architectural review
+## Long-context scaling (4096 → 32768, pure Int8 vs ONNX Int8)
 
-- **Attention is BLAS-1, not BLAS-3.** `Gemma3Model.AttentionRow` computes scores as `seq²·heads`
-  individual `TensorPrimitives.Dot` calls and the context as `seq²·heads` `MultiplyAdd` calls. The HF
-  reference (`eager_attention_forward`) computes `attn = matmul(Q, Kᵀ) * scale` and `matmul(softmax, V)`
-  as two **batched GEMMs** (or fused `scaled_dot_product_attention`) — cache-blocked, multi-threaded
-  oneDNN/MKL, with K/V reused across all query rows instead of re-streamed per pair.
-- **Projections are GEMV-per-row, not GEMM.** `Ops.LinearColumn` (fp32) does one `Dot` per
-  `(output, seq)` with no register/cache blocking — PyTorch uses a tuned BLAS-3 GEMM. (The **Int8**
-  path *does* register-tile, which is exactly why Int8 beats fp32 on projection-bound lengths.)
-- **Threading default.** `-1` (the .NET "unbounded" sentinel) is treated as single-threaded by
-  `ParallelExecution.ForAsync`; the query path passes `ProcessorCount` explicitly, the document path
-  does not.
+_Filled in by `harrier-scaling-long` (single encode per point; O(n²) makes 32768 a multi-minute encode)._
 
-### int8-specific differences (vs the PyTorch ecosystem / ONNX int8)
+| Tokens | Pure Int8 (ms) | ONNX Int8 (ms) | ratio |
+|-------:|---------------:|---------------:|------:|
+| _pending_ | | | |
 
-- **Scope:** only the 7 linear projections are int8; `Q·Kᵀ`/softmax/`·V` stay fp32. So Int8 cannot
-  touch the O(n²) term — its speed-up vanishes as sequences grow.
-- **Dynamic per-row activation quant, recomputed & redundant:** `q/k/v` each re-quantize the *same*
-  `normed` activation (3×); `gate/up` re-quantize their shared input (2×) — 5 passes/layer for 2
-  distinct activations.
-- **Scheme:** per-output-channel symmetric weights (no zero-point) + per-row symmetric activations
-  (+128 uint8 offset for `vpdpbusd`, corrected by `rowSum`). **No outlier handling** (cf. LLM.int8()'s
-  fp16 outlier decomposition).
-- **Kernel:** register-tiled (4 out × 2–4 seq, VNNI `vpdpbusd`) but still hand-rolled per-tile, not a
-  tuned BLAS-3 library GEMM. Non-VNNI CPUs fall back to weight-only (dequant to fp32).
-- **Apples-to-apples int8** would compare against the ONNX `model_quantized.onnx` graph and/or a
-  `torch.ao` dynamically-quantized PyTorch model — not the fp32 Python reference.
-
-## Practical takeaways
-
-- The pure package's value is **zero native dependencies / AOT & WASM portability**, not peak CPU
-  throughput. For server-side throughput, ONNX (or PyTorch) is materially faster.
-- Two cheap wins for the pure path: **(1) pass `MaxDegreeOfParallelism = ProcessorCount`** to the
-  encode call (3–4×), and **(2) prefer shorter chunks** — every path pays a super-linear penalty per
-  chunk, and the pure path most of all.
-- Bigger structural win (not done here): replace the per-pair attention and per-row projection loops
-  with blocked GEMM kernels (and quantize the attention matmuls) to attack both the constant factor and
-  the quadratic term.
-
-_Reproduce: `dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-scaling`,
-`-- harrier-scaling-pure Int8`, `-- harrier-profile 1` / `-- harrier-profile 4`, then
-`python scripts/harrier_scaling_bench.py`._
+## Reproduce
+```
+dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-scaling          # 128..4096, 4 impls
+dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-scaling-long      # 4096..32768, Int8
+dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-profile 4 Int8    # per-stage profile
+dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-verify-fma        # attention correctness gate
+python scripts/harrier_scaling_bench.py                                                     # PyTorch reference
+```

--- a/SentenceTransformers.Benchmark/HARRIER-SCALING.md
+++ b/SentenceTransformers.Benchmark/HARRIER-SCALING.md
@@ -1,12 +1,11 @@
 # Harrier Small — token-count scalability
 
-Elapsed time per single-sentence encode (`EncodeAsync` / `model.encode`) for the
-`harrier-oss-v1-270m` model, swept across sequence lengths from 128 to 4096 tokens.
+Elapsed time per single-sentence encode for the `harrier-oss-v1-270m` model, swept across sequence
+lengths from 128 to 4096 tokens, for four implementations of the same model.
 
-All three implementations were driven with **byte-identical calibrated input strings**
-(generated once and replayed from `/tmp/harrier_scaling_inputs.json`), each calibrated
-to land on an exact token count (incl. `<bos>`/`<eos>`) using the shared Gemma BPE
-tokenizer. Token counts matched exactly across all three.
+All were driven with **byte-identical calibrated input strings** (generated once and replayed from
+`/tmp/harrier_scaling_inputs.json`), each calibrated to land on an exact token count (incl.
+`<bos>`/`<eos>`) using the shared Gemma BPE tokenizer. Token counts matched exactly across all paths.
 
 ## Environment
 
@@ -14,71 +13,124 @@ tokenizer. Token counts matched exactly across all three.
 |---|---|
 | CPU | 4 cores (CPU-only, no GPU) |
 | RAM | 15 GiB |
-| Pure C# | `SentenceTransformers.Harrier.Small.Pure`, fp32, .NET 10, Release |
-| ONNX C# | `SentenceTransformers.Harrier.Small`, ONNX Runtime 1.24.2, **Q4F16** (default variant) |
+| Pure C# | `SentenceTransformers.Harrier.Small.Pure`, .NET 10, Release, fp32 and Int8 |
+| ONNX C# | `SentenceTransformers.Harrier.Small`, ONNX Runtime 1.24.2, **Q4F16** (package default) |
 | Python | `sentence-transformers` 5.5.1 / `transformers` 5.12.0 / torch 2.12.0, CPU, fp32 |
 | Method | warmup encode, then median of N iters (7/5/3/2/1 as length grows) |
 
-> Note: this is **not** a like-for-like precision comparison. Pure C# and Python run
-> full **fp32**; the ONNX column is the **Q4F16-quantized** graph (the package default,
-> smallest on disk), which is why it is the fastest. The numbers measure each shipping
-> default as you would actually use it.
+> **Important threading caveat.** The pure columns below were produced by the public document
+> `EncodeAsync(string[])` path, which builds a default `ParallelOptions` (`MaxDegreeOfParallelism == -1`).
+> `ParallelExecution.ForAsync` only fans out when `MaxDegreeOfParallelism > 1`, and `-1` is *not* `> 1`,
+> so **the pure encoder ran single-threaded on 1 of 4 cores**, while ONNX and PyTorch used all 4.
+> Re-running the pure path with an explicit `MaxDegreeOfParallelism = 4` is **3.2–3.7× faster** (see the
+> profile section). The numbers below reflect each path's *shipping default*, which is itself a finding.
+>
+> This is also **not** a same-precision comparison: Pure-fp32 and Python are fp32; Pure-Int8 is weight+
+> activation int8 (projections only); ONNX is Q4F16. See `int8` notes below.
 
 ## Results — elapsed ms per encode
 
-| Tokens | Pure C# fp32 (ms) | Python fp32 (ms) | ONNX Q4F16 (ms) |
-|-------:|------------------:|-----------------:|----------------:|
-|    128 |           1,778.4 |            349.9 |           117.4 |
-|    256 |           3,838.4 |            589.5 |           287.1 |
-|    512 |           8,053.9 |          1,092.8 |           587.5 |
-|  1,024 |          18,819.7 |          2,166.8 |         1,178.2 |
-|  2,048 |          46,789.5 |          4,293.7 |         2,740.6 |
-|  4,096 |         120,825.7 |          9,571.8 |         7,105.0 |
+| Tokens | Pure fp32 (1 core) | Pure Int8 (1 core) | Python fp32 (4 core) | ONNX Q4F16 (4 core) |
+|-------:|-------------------:|-------------------:|---------------------:|--------------------:|
+|    128 |            1,778.4 |              670.8 |                349.9 |               117.4 |
+|    256 |            3,838.4 |            1,406.9 |                589.5 |               287.1 |
+|    512 |            8,053.9 |            3,310.2 |              1,092.8 |               587.5 |
+|  1,024 |           18,819.7 |            8,688.6 |              2,166.8 |             1,178.2 |
+|  2,048 |           46,789.5 |           27,208.7 |              4,293.7 |             2,740.6 |
+|  4,096 |          120,825.7 |           85,162.8 |              9,571.8 |             7,105.0 |
 
 ## Throughput — tokens/second (higher is better)
 
-| Tokens | Pure C# fp32 | Python fp32 | ONNX Q4F16 |
-|-------:|-------------:|------------:|-----------:|
-|    128 |           72 |         366 |      1,090 |
-|    256 |           67 |         434 |        892 |
-|    512 |           64 |         469 |        872 |
-|  1,024 |           54 |         473 |        869 |
-|  2,048 |           44 |         477 |        747 |
-|  4,096 |           34 |         428 |        577 |
+| Tokens | Pure fp32 | Pure Int8 | Python fp32 | ONNX Q4F16 |
+|-------:|----------:|----------:|------------:|-----------:|
+|    128 |        72 |       191 |         366 |      1,090 |
+|    256 |        67 |       182 |         434 |        892 |
+|    512 |        64 |       155 |         469 |        872 |
+|  1,024 |        54 |       118 |         473 |        869 |
+|  2,048 |        44 |        75 |         477 |        747 |
+|  4,096 |        34 |        48 |         428 |        577 |
 
-## How each scales
+## How each scales (128 → 4096, i.e. 32× more tokens)
 
-Cost relative to the 128-token point (32× more tokens = perfectly-linear 32×):
+| | growth | note |
+|---|---:|---|
+| Pure fp32 | **68×** | super-linear: O(n²) attention term grows in |
+| Pure Int8 | **127×** | *worse* ratio — Int8 shrinks only the linear projections, so the unquantized fp32 attention dominates faster |
+| ONNX Q4F16 | **61×** | super-linear |
+| Python fp32 | **27×** | ~300 ms fixed per-call floor dilutes the ratio |
 
-| | 128→4096 growth | per-doubling factor (avg) |
-|---|---:|---:|
-| Pure C# fp32 | **68×** | ~2.3× |
-| ONNX Q4F16   | **61×** | ~2.3× |
-| Python fp32  | **27×** | ~2.0× |
+Int8 is 2.6× faster than fp32 at 128 tokens but only **1.4× faster at 4096** — direct evidence that
+quantization helps the projections but **not attention**, which is fp32 in both.
 
-All three are **super-linear** in token count, as expected from the O(n²) self-attention
-term that grows relative to the O(n) projection/MLP work as sequences lengthen — visible
-in the per-doubling factor climbing toward ~2.6× at the top end for the C# paths.
+## Where the time goes — per-stage profile of the pure fp32 forward
 
-Python's growth ratio looks the smallest only because it carries a larger fixed
-per-call overhead (~300 ms floor of Python/dispatch + framework), which dominates at
-128 tokens and dilutes the ratio; in absolute tokens/sec it plateaus around ~470 tok/s.
+Captured with the opt-in `ForwardProfile` (`harrier-profile <maxDop>`). Stopwatch/lock overhead inflates
+the absolute totals ~20–40 % vs the clean benchmark, but the proportions and the DOP speed-ups are
+accurate.
 
-## Takeaways
+**Single-threaded (MaxDop=1):**
 
-- **ONNX Q4F16 is fastest end-to-end** at every length (≈1.3–3× faster than PyTorch CPU,
-  ≈15× faster than the pure-C# fp32 path at short lengths, ≈17× at 4096) — quantization
-  plus a mature CPU kernel library does the heavy lifting.
-- **PyTorch (sentence-transformers) fp32** is the mid-point: a well-optimized BLAS backend
-  beats the managed fp32 kernels comfortably, but loses to the quantized ONNX graph.
-- **Pure C# fp32** is the slowest (its whole point is zero native dependencies / AOT-&-WASM
-  portability, not peak throughput) and is the most sensitive to length: at 4096 tokens a
-  single encode takes ~2 minutes on 4 cores. For long-context throughput-bound workloads
-  it would benefit most from quantization (`Int8`/`Int4`) and/or chunking to shorter
-  sequences.
-- Practically: for indexing large documents, prefer shorter chunks — every path pays a
-  super-linear penalty per chunk as the chunk grows, so two 512-token chunks are
-  meaningfully cheaper than one 1024-token chunk on the pure path especially.
+| Stage | 512 tok | 2048 tok | 4096 tok |
+|---|--:|--:|--:|
+| projections — mlp (gate/up/down) | 60.9% | 49.9% | 41.3% |
+| projections — qkv | 14.8% | 12.0% | 8.8% |
+| projections — o | 10.1% | 7.8% | 6.4% |
+| **attention (Q·Kᵀ, softmax, ·V)** | **8.5%** | **26.3%** | **40.5%** |
+| geglu | 4.9% | 3.5% | 2.6% |
+| norms + residual + rope | 0.8% | 0.6% | 0.4% |
+| total (ms) | 11,189 | 62,515 | 167,661 |
 
-_Reproduce: `dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-scaling`
-then `python scripts/harrier_scaling_bench.py`._
+**Multi-threaded (MaxDop=4) total ms:** 512 → 3,532 (**3.2×**), 2048 → 17,530 (**3.6×**), 4096 → 45,417 (**3.7×**).
+
+Takeaways from the profile:
+1. At short/medium lengths the bottleneck is the **fp32 projection matmuls (~85 % at 512)**, *not*
+   attention. Attention only becomes co-dominant at 4096 (40 %). This is why Int8 (which has tiled
+   VNNI kernels for the projections) gives a big win at short lengths.
+2. The pure path leaves **3.2–3.7× on the table** by defaulting to single-threaded in the document
+   `EncodeAsync` path.
+3. `geglu`, `rmsnorm`, `rope`, `headnorm` are **serial** loops (not parallelized), so their relative
+   share grows under MaxDop=4 (geglu 4.9 % → 15.9 % at 512).
+
+## Why pure is slower than PyTorch/ONNX — architectural review
+
+- **Attention is BLAS-1, not BLAS-3.** `Gemma3Model.AttentionRow` computes scores as `seq²·heads`
+  individual `TensorPrimitives.Dot` calls and the context as `seq²·heads` `MultiplyAdd` calls. The HF
+  reference (`eager_attention_forward`) computes `attn = matmul(Q, Kᵀ) * scale` and `matmul(softmax, V)`
+  as two **batched GEMMs** (or fused `scaled_dot_product_attention`) — cache-blocked, multi-threaded
+  oneDNN/MKL, with K/V reused across all query rows instead of re-streamed per pair.
+- **Projections are GEMV-per-row, not GEMM.** `Ops.LinearColumn` (fp32) does one `Dot` per
+  `(output, seq)` with no register/cache blocking — PyTorch uses a tuned BLAS-3 GEMM. (The **Int8**
+  path *does* register-tile, which is exactly why Int8 beats fp32 on projection-bound lengths.)
+- **Threading default.** `-1` (the .NET "unbounded" sentinel) is treated as single-threaded by
+  `ParallelExecution.ForAsync`; the query path passes `ProcessorCount` explicitly, the document path
+  does not.
+
+### int8-specific differences (vs the PyTorch ecosystem / ONNX int8)
+
+- **Scope:** only the 7 linear projections are int8; `Q·Kᵀ`/softmax/`·V` stay fp32. So Int8 cannot
+  touch the O(n²) term — its speed-up vanishes as sequences grow.
+- **Dynamic per-row activation quant, recomputed & redundant:** `q/k/v` each re-quantize the *same*
+  `normed` activation (3×); `gate/up` re-quantize their shared input (2×) — 5 passes/layer for 2
+  distinct activations.
+- **Scheme:** per-output-channel symmetric weights (no zero-point) + per-row symmetric activations
+  (+128 uint8 offset for `vpdpbusd`, corrected by `rowSum`). **No outlier handling** (cf. LLM.int8()'s
+  fp16 outlier decomposition).
+- **Kernel:** register-tiled (4 out × 2–4 seq, VNNI `vpdpbusd`) but still hand-rolled per-tile, not a
+  tuned BLAS-3 library GEMM. Non-VNNI CPUs fall back to weight-only (dequant to fp32).
+- **Apples-to-apples int8** would compare against the ONNX `model_quantized.onnx` graph and/or a
+  `torch.ao` dynamically-quantized PyTorch model — not the fp32 Python reference.
+
+## Practical takeaways
+
+- The pure package's value is **zero native dependencies / AOT & WASM portability**, not peak CPU
+  throughput. For server-side throughput, ONNX (or PyTorch) is materially faster.
+- Two cheap wins for the pure path: **(1) pass `MaxDegreeOfParallelism = ProcessorCount`** to the
+  encode call (3–4×), and **(2) prefer shorter chunks** — every path pays a super-linear penalty per
+  chunk, and the pure path most of all.
+- Bigger structural win (not done here): replace the per-pair attention and per-row projection loops
+  with blocked GEMM kernels (and quantize the attention matmuls) to attack both the constant factor and
+  the quadratic term.
+
+_Reproduce: `dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-scaling`,
+`-- harrier-scaling-pure Int8`, `-- harrier-profile 1` / `-- harrier-profile 4`, then
+`python scripts/harrier_scaling_bench.py`._

--- a/SentenceTransformers.Benchmark/HARRIER-SCALING.md
+++ b/SentenceTransformers.Benchmark/HARRIER-SCALING.md
@@ -75,21 +75,34 @@ Per-stage Int8 profile (4 cores), final kernels:
 single-threaded original **85,163 ms** → max cores + vectorized GeGLU + head-fused block-flash
 **13,735 ms** — **6.2× faster**.
 
-## Honest parity assessment
-- **Short/medium contexts (≤~256 tokens): parity reached** — pure Int8 (197 ms @128) actually beats
-  ONNX Int8 (209 ms), and is competitive to ~512.
-- **Long contexts: ~1.9× off at 4096**, and the gap is essentially all attention. The pure attention is
-  ~18 GFLOP/s/core; ONNX (MLAS-backed `GroupQueryAttention`) is ~2.5× higher. Closing the rest needs
-  either an MLAS-class packed/blocked fp32 GEMM microkernel or **int8/VNNI attention matmuls** (4× less
-  K/V memory traffic + VNNI throughput) — the remaining lever, with a small extra accuracy cost.
+## Long-context scaling (→ 32768, the full context window) — pure Int8 vs ONNX Int8
 
-## Long-context scaling (4096 → 32768, pure Int8 vs ONNX Int8)
-
-_Filled in by `harrier-scaling-long` (single encode per point; O(n²) makes 32768 a multi-minute encode)._
+Single encode per point on max cores (O(n²) makes 32768 a multi-minute encode):
 
 | Tokens | Pure Int8 (ms) | ONNX Int8 (ms) | ratio |
 |-------:|---------------:|---------------:|------:|
-| _pending_ | | | |
+|  4,669 |       17,059 |        11,072 | 1.54× |
+|  9,336 |       58,747 |        40,630 | 1.45× |
+| 18,669 |      232,509 |       187,555 | 1.24× |
+| 32,768 |  **714,956** | **OOM** (needs 16 GB) | pure completes |
+
+Two findings here:
+1. **The ratio improves with length (1.54× → 1.24×)** — the pure flash kernel scales *as well or better*
+   than ONNX's CPU attention as the quadratic term takes over.
+2. **At the full 32,768 context window ONNX Int8 OOMs and pure Int8 succeeds.** ONNX Runtime's CPU
+   `GroupQueryAttention` materializes the full `[heads, seq, seq]` score tensor — at 32768 that is
+   `32768² × 4 heads × 4 B ≈ 16 GB`, which fails to allocate on the 15 GiB box. The pure kernel's
+   online-softmax (block-flash) never materializes the score matrix, so it runs in O(seq) attention
+   memory and completes.
+
+## Honest parity assessment
+- **Short/medium contexts (≤~256 tokens): at parity or better** — pure Int8 (197 ms @128) beats ONNX
+  Int8 (209 ms), competitive to ~512.
+- **Mid contexts (1k–4k): ~1.6–1.9× off**, entirely attention throughput (pure ~18 GFLOP/s/core vs
+  MLAS-backed ONNX ~2.5×). The remaining lever for raw throughput is int8/VNNI attention matmuls
+  (4× less K/V traffic), with a small extra accuracy cost.
+- **Long contexts (8k–32k): the gap *narrows* (down to 1.24×) and pure becomes strictly more scalable
+  in memory** — it is the only one of the two that completes a 32768-token encode on this machine.
 
 ## Reproduce
 ```

--- a/SentenceTransformers.Benchmark/HARRIER-SCALING.md
+++ b/SentenceTransformers.Benchmark/HARRIER-SCALING.md
@@ -17,15 +17,16 @@ ONNX Q4F16 (`model_q4f16`) and Int8 (`model_quantized`, `MatMulNBits` + fused `G
 
 | Tokens | Pure fp32 | Pure Int8 | ONNX Q4F16 | ONNX Int8 | Pure Int8 / ONNX Int8 |
 |-------:|----------:|----------:|-----------:|----------:|----------------------:|
-|    128 |     652.9 |   **197.2** |      125.8 |     209.2 | **0.94× (pure wins)** |
-|    256 |   1,381.3 |     367.8 |      255.9 |     297.6 | 1.24× |
-|    512 |   2,947.4 |     809.2 |      529.5 |     508.2 | 1.59× |
-|  1,024 |   6,472.7 |   1,885.0 |    1,227.1 |   1,018.7 | 1.85× |
-|  2,048 |  13,866.9 |   4,909.3 |    3,236.7 |   2,767.5 | 1.77× |
-|  4,096 |  34,663.2 |  13,735.5 |    8,778.4 |   7,367.6 | 1.86× |
+|    128 |     678.8 |   **196.6** |      176.3 |     262.5 | **0.75× (pure wins)** |
+|    256 |   1,332.2 |     402.0 |      328.1 |     356.1 | 1.13× |
+|    512 |   2,931.2 |     833.4 |      663.2 |     615.3 | 1.35× |
+|  1,024 |   6,492.1 |   1,838.5 |    1,430.1 |   1,111.8 | 1.65× |
+|  2,048 |  14,355.3 |   4,781.8 |    3,405.3 |   2,618.3 | 1.83× |
+|  4,096 |  33,919.5 |  13,124.8 |    8,888.8 |   8,016.1 | 1.64× |
 
-Short contexts (≤256 tokens) are at or beyond ONNX-Int8 parity; the residual gap at long contexts is
-entirely attention (below).
+Short contexts (≤256 tokens) are at or beyond ONNX-Int8 parity (pure is faster at 128); the residual gap
+at longer contexts is entirely attention (below). The Pure-Int8 column includes the int8/VNNI attention
+scores (§2).
 
 ## What was optimized (and the journey)
 
@@ -47,33 +48,42 @@ vectorized kernel (`TensorPrimitives` incl. vectorized tanh):
 Several kernels were implemented and measured (all gated by a `verify-fma` correctness check: fp32 stays
 cos = 1.0 vs the reference path, Int8 cos ≈ 0.998 — within the expected quantization tolerance):
 
+Several kernels were implemented and measured (all gated by correctness checks: fp32 stays cos = 1.0 vs
+the reference path; Int8 stays cos ≈ 0.99 / ≥ 0.984 vs the PyTorch golden — within quantization tolerance):
+
 | attention kernel (Int8, 4 cores, 4096 tok) | attention ms | verdict |
 |---|--:|---|
 | original naive per-(query,head) dot | ~10,500 | baseline |
 | cache-blocked + 4-head-fused (bit-identical) | ~10,486 | ~same (memory-bound) |
-| FMA register-tiled (4×2 score GEMM) | ~10,545 | no gain → **compute is not the limit** |
+| FMA register-tiled (4×2 score GEMM) | ~10,545 | no gain → **fp32 compute is not the limit** |
 | naive online-softmax flash | ~28,000 (2048: 5,000) | **worse** — scalar `exp` ≫ vectorized exp |
-| **head-fused block-flash (chosen)** | **8,661** | **best** |
+| head-fused block-flash (fp32 scores) | 8,661 | good |
+| **+ int8/VNNI scores (chosen)** | **7,680** | **best** |
+| + int8 value too | 8,399 | reverted — V is cache-resident, convert overhead > memory saving |
 
-The winning kernel (`FlashAttentionBlock`) combines every lever: it streams keys in L1-sized chunks with
-an **online softmax** (no seq×seq score matrix materialized — that buffer's traffic was the bottleneck),
-keeps a **large query block** so each K/V chunk is reused across many queries, **fuses the 4 GQA query
-heads** into one SIMD pass per key (`ScoreHeads4`/`AxpyHeads4`), and keeps `exp` **vectorized** by
-applying it per chunk. This mirrors ONNX's fused `GroupQueryAttention`.
+The winning kernel (`FlashAttentionBlock` / `FlashAttentionBlockInt8`) combines every lever: it streams
+keys in L1-sized chunks with an **online softmax** (no seq×seq score matrix materialized — that buffer's
+traffic was the bottleneck), keeps a **large query block** so each K/V chunk is reused across many
+queries, **fuses the 4 GQA query heads** into one SIMD pass per key, and keeps `exp` **vectorized** per
+chunk. For quantized modes the **scores use an int8 `vpdpbusd` dot** over per-row-quantized Q (uint8) and
+K (int8), so K is read at 1 byte/element (4× less than fp32 — attention is memory-bound) with a VNNI
+compute win on top. This mirrors ONNX's fused `GroupQueryAttention`. The **value matmul stays fp32**:
+quantizing V was measured *slower* because the block-flash already keeps each V chunk cache-resident
+(reused across the query block), so the int8→float convert costs more than the memory it saves.
 
 Per-stage Int8 profile (4 cores), final kernels:
 
 | Stage | 512 | 2048 | 4096 |
 |---|--:|--:|--:|
-| attention | 201 | 2,315 | 8,661 |
-| mlp_proj (Int8 VNNI) | 441 | 1,644 | 3,204 |
-| qkv+o (Int8 VNNI) | 263 | 781 | 1,479 |
-| geglu | 24 | 84 | 165 |
-| norms+rope | 122 | 413 | 811 |
+| attention (int8 scores) | 176 | 1,934 | 7,680 |
+| mlp_proj (Int8 VNNI) | 367 | 1,540 | 3,076 |
+| qkv+o (Int8 VNNI) | 197 | 761 | 1,512 |
+| geglu | 19 | 77 | 158 |
+| norms+rope | 110 | 378 | 813 |
 
 ### Net effect (Pure Int8 @ 4096, this box)
-single-threaded original **85,163 ms** → max cores + vectorized GeGLU + head-fused block-flash
-**13,735 ms** — **6.2× faster**.
+single-threaded original **85,163 ms** → max cores + vectorized GeGLU + head-fused block-flash + int8/VNNI
+scores **13,125 ms** — **6.5× faster**, and the Int8/ONNX-Int8 gap at 4096 narrowed from 2.0× to **1.64×**.
 
 ## Long-context scaling (→ 32768, the full context window) — pure Int8 vs ONNX Int8
 
@@ -96,13 +106,14 @@ Two findings here:
    memory and completes.
 
 ## Honest parity assessment
-- **Short/medium contexts (≤~256 tokens): at parity or better** — pure Int8 (197 ms @128) beats ONNX
-  Int8 (209 ms), competitive to ~512.
-- **Mid contexts (1k–4k): ~1.6–1.9× off**, entirely attention throughput (pure ~18 GFLOP/s/core vs
-  MLAS-backed ONNX ~2.5×). The remaining lever for raw throughput is int8/VNNI attention matmuls
-  (4× less K/V traffic), with a small extra accuracy cost.
+- **Short contexts (≤~256 tokens): at parity or better** — pure Int8 (197 ms @128) beats ONNX Int8
+  (262 ms), competitive to ~512.
+- **Mid contexts (1k–4k): ~1.6–1.8× off**, entirely attention throughput. int8/VNNI scores closed part of
+  the gap (4096 went 2.0× → 1.64×); the rest is the fp32 value matmul + ONNX's MLAS-class kernels. Further
+  gains would need an MLAS-style packed GEMM for the value matmul (int8 value did not help — see §2).
 - **Long contexts (8k–32k): the gap *narrows* (down to 1.24×) and pure becomes strictly more scalable
-  in memory** — it is the only one of the two that completes a 32768-token encode on this machine.
+  in memory** — it is the only one of the two that completes a 32768-token encode on this machine
+  (ONNX OOMs materializing the full score tensor).
 
 ## Reproduce
 ```

--- a/SentenceTransformers.Benchmark/HARRIER-SCALING.md
+++ b/SentenceTransformers.Benchmark/HARRIER-SCALING.md
@@ -17,16 +17,16 @@ ONNX Q4F16 (`model_q4f16`) and Int8 (`model_quantized`, `MatMulNBits` + fused `G
 
 | Tokens | Pure fp32 | Pure Int8 | ONNX Q4F16 | ONNX Int8 | Pure Int8 / ONNX Int8 |
 |-------:|----------:|----------:|-----------:|----------:|----------------------:|
-|    128 |     678.8 |   **196.6** |      176.3 |     262.5 | **0.75× (pure wins)** |
-|    256 |   1,332.2 |     402.0 |      328.1 |     356.1 | 1.13× |
-|    512 |   2,931.2 |     833.4 |      663.2 |     615.3 | 1.35× |
-|  1,024 |   6,492.1 |   1,838.5 |    1,430.1 |   1,111.8 | 1.65× |
-|  2,048 |  14,355.3 |   4,781.8 |    3,405.3 |   2,618.3 | 1.83× |
-|  4,096 |  33,919.5 |  13,124.8 |    8,888.8 |   8,016.1 | 1.64× |
+|    128 |     419.5 |   **107.8** |      106.0 |     141.7 | **0.76× (pure wins)** |
+|    256 |     742.5 |   **202.9** |      208.1 |     219.5 | **0.92× (pure wins)** |
+|    512 |   1,598.3 |     518.0 |      451.3 |     363.2 | 1.43× |
+|  1,024 |   4,043.1 |   1,160.6 |      996.2 |     794.7 | 1.46× |
+|  2,048 |   9,170.4 |   2,883.0 |    2,414.1 |   1,889.8 | 1.53× |
+|  4,096 |  21,248.6 |   7,925.6 |    6,872.4 |   5,194.8 | 1.53× |
 
-Short contexts (≤256 tokens) are at or beyond ONNX-Int8 parity (pure is faster at 128); the residual gap
-at longer contexts is entirely attention (below). The Pure-Int8 column includes the int8/VNNI attention
-scores (§2).
+Pure Int8 now beats ONNX Int8 up to 256 tokens and the long-context gap is ~1.5×. The Pure-Int8 column
+includes int8/VNNI attention scores (§2) and 512-bit AVX-512 kernels (§3). _(Absolute ms vary with this
+shared cloud box's load between runs; the controlled comparisons below toggle one variable at a time.)_
 
 ## What was optimized (and the journey)
 
@@ -81,9 +81,28 @@ Per-stage Int8 profile (4 cores), final kernels:
 | geglu | 19 | 77 | 158 |
 | norms+rope | 110 | 378 | 813 |
 
-### Net effect (Pure Int8 @ 4096, this box)
-single-threaded original **85,163 ms** → max cores + vectorized GeGLU + head-fused block-flash + int8/VNNI
-scores **13,125 ms** — **6.5× faster**, and the Int8/ONNX-Int8 gap at 4096 narrowed from 2.0× to **1.64×**.
+### 3. AVX-512 (512-bit) kernels
+The attention kernels were 256-bit (`Vector256` / `vpdpbusd` on ymm). On an AVX-512 host they now run
+512-bit, selected by `IsSupported` bool flags (JIT constants — the 256-bit body is dead-code-eliminated
+on non-AVX-512 CPUs, the standard .NET pattern): the **int8 scores** use a 512-bit VNNI dot
+(`Vnni.DotAccumulate512`, 64 int8 MACs/instr) and the **value / scale kernels** use 512-bit FMA
+(`Avx512F.FusedMultiplyAdd`, 16 floats/lane). The int8 projection GEMMs already had a 512-bit path.
+
+Controlled toggle (`DOTNET_EnableAVX512=0` vs default, same box, Int8, 4 cores), total ms per encode:
+
+| | 512 tok | 2048 tok | 4096 tok |
+|---|--:|--:|--:|
+| 256-bit | 650 | 3,558 | 8,836 |
+| **512-bit** | **597** | **2,591** | **7,053** |
+| speedup | 1.08× | 1.37× | 1.25× |
+
+(attention 4096: 4,568→3,990 ms; int8 projections 4096: 2,367→1,551 ms.) AVX-512 has a small fixed
+overhead/downclock that shows at very short sequences but wins clearly from ~1k tokens up.
+
+### Net effect (Pure Int8)
+single-threaded original → max cores + vectorized GeGLU + head-fused block-flash + int8/VNNI scores +
+AVX-512: roughly **6–8× faster** end-to-end (exact factor drifts with the shared box's load), and the
+Int8/ONNX-Int8 gap went from ~2.0× to **~1.5× at 4096, with pure faster at ≤256 tokens**.
 
 ## Long-context scaling (→ 32768, the full context window) — pure Int8 vs ONNX Int8
 
@@ -106,13 +125,12 @@ Two findings here:
    memory and completes.
 
 ## Honest parity assessment
-- **Short contexts (≤~256 tokens): at parity or better** — pure Int8 (197 ms @128) beats ONNX Int8
-  (262 ms), competitive to ~512.
-- **Mid contexts (1k–4k): ~1.6–1.8× off**, entirely attention throughput. int8/VNNI scores closed part of
-  the gap (4096 went 2.0× → 1.64×); the rest is the fp32 value matmul + ONNX's MLAS-class kernels. Further
-  gains would need an MLAS-style packed GEMM for the value matmul (int8 value did not help — see §2).
-- **Long contexts (8k–32k): the gap *narrows* (down to 1.24×) and pure becomes strictly more scalable
-  in memory** — it is the only one of the two that completes a 32768-token encode on this machine
+- **Short contexts (≤256 tokens): pure Int8 is now faster than ONNX Int8** (128: 0.76×, 256: 0.92×).
+- **Mid contexts (512–4k): ~1.4–1.5× off**, narrowed from ~2.0× by int8/VNNI scores + AVX-512. The
+  residual is the fp32 value matmul and ONNX's MLAS-class kernels. The next lever is an MLAS-style packed
+  GEMM for the value matmul (int8 value did not help — V is cache-resident, see §2).
+- **Long contexts (8k–32k): the gap *narrows* further (to ~1.24×) and pure is strictly more scalable in
+  memory** — it is the only one of the two that completes a 32768-token encode on this machine
   (ONNX OOMs materializing the full score tensor).
 
 ## Reproduce

--- a/SentenceTransformers.Benchmark/HARRIER-SCALING.md
+++ b/SentenceTransformers.Benchmark/HARRIER-SCALING.md
@@ -1,0 +1,84 @@
+# Harrier Small — token-count scalability
+
+Elapsed time per single-sentence encode (`EncodeAsync` / `model.encode`) for the
+`harrier-oss-v1-270m` model, swept across sequence lengths from 128 to 4096 tokens.
+
+All three implementations were driven with **byte-identical calibrated input strings**
+(generated once and replayed from `/tmp/harrier_scaling_inputs.json`), each calibrated
+to land on an exact token count (incl. `<bos>`/`<eos>`) using the shared Gemma BPE
+tokenizer. Token counts matched exactly across all three.
+
+## Environment
+
+| | |
+|---|---|
+| CPU | 4 cores (CPU-only, no GPU) |
+| RAM | 15 GiB |
+| Pure C# | `SentenceTransformers.Harrier.Small.Pure`, fp32, .NET 10, Release |
+| ONNX C# | `SentenceTransformers.Harrier.Small`, ONNX Runtime 1.24.2, **Q4F16** (default variant) |
+| Python | `sentence-transformers` 5.5.1 / `transformers` 5.12.0 / torch 2.12.0, CPU, fp32 |
+| Method | warmup encode, then median of N iters (7/5/3/2/1 as length grows) |
+
+> Note: this is **not** a like-for-like precision comparison. Pure C# and Python run
+> full **fp32**; the ONNX column is the **Q4F16-quantized** graph (the package default,
+> smallest on disk), which is why it is the fastest. The numbers measure each shipping
+> default as you would actually use it.
+
+## Results — elapsed ms per encode
+
+| Tokens | Pure C# fp32 (ms) | Python fp32 (ms) | ONNX Q4F16 (ms) |
+|-------:|------------------:|-----------------:|----------------:|
+|    128 |           1,778.4 |            349.9 |           117.4 |
+|    256 |           3,838.4 |            589.5 |           287.1 |
+|    512 |           8,053.9 |          1,092.8 |           587.5 |
+|  1,024 |          18,819.7 |          2,166.8 |         1,178.2 |
+|  2,048 |          46,789.5 |          4,293.7 |         2,740.6 |
+|  4,096 |         120,825.7 |          9,571.8 |         7,105.0 |
+
+## Throughput — tokens/second (higher is better)
+
+| Tokens | Pure C# fp32 | Python fp32 | ONNX Q4F16 |
+|-------:|-------------:|------------:|-----------:|
+|    128 |           72 |         366 |      1,090 |
+|    256 |           67 |         434 |        892 |
+|    512 |           64 |         469 |        872 |
+|  1,024 |           54 |         473 |        869 |
+|  2,048 |           44 |         477 |        747 |
+|  4,096 |           34 |         428 |        577 |
+
+## How each scales
+
+Cost relative to the 128-token point (32× more tokens = perfectly-linear 32×):
+
+| | 128→4096 growth | per-doubling factor (avg) |
+|---|---:|---:|
+| Pure C# fp32 | **68×** | ~2.3× |
+| ONNX Q4F16   | **61×** | ~2.3× |
+| Python fp32  | **27×** | ~2.0× |
+
+All three are **super-linear** in token count, as expected from the O(n²) self-attention
+term that grows relative to the O(n) projection/MLP work as sequences lengthen — visible
+in the per-doubling factor climbing toward ~2.6× at the top end for the C# paths.
+
+Python's growth ratio looks the smallest only because it carries a larger fixed
+per-call overhead (~300 ms floor of Python/dispatch + framework), which dominates at
+128 tokens and dilutes the ratio; in absolute tokens/sec it plateaus around ~470 tok/s.
+
+## Takeaways
+
+- **ONNX Q4F16 is fastest end-to-end** at every length (≈1.3–3× faster than PyTorch CPU,
+  ≈15× faster than the pure-C# fp32 path at short lengths, ≈17× at 4096) — quantization
+  plus a mature CPU kernel library does the heavy lifting.
+- **PyTorch (sentence-transformers) fp32** is the mid-point: a well-optimized BLAS backend
+  beats the managed fp32 kernels comfortably, but loses to the quantized ONNX graph.
+- **Pure C# fp32** is the slowest (its whole point is zero native dependencies / AOT-&-WASM
+  portability, not peak throughput) and is the most sensitive to length: at 4096 tokens a
+  single encode takes ~2 minutes on 4 cores. For long-context throughput-bound workloads
+  it would benefit most from quantization (`Int8`/`Int4`) and/or chunking to shorter
+  sequences.
+- Practically: for indexing large documents, prefer shorter chunks — every path pays a
+  super-linear penalty per chunk as the chunk grows, so two 512-token chunks are
+  meaningfully cheaper than one 1024-token chunk on the pure path especially.
+
+_Reproduce: `dotnet run -c Release --project SentenceTransformers.Benchmark -- harrier-scaling`
+then `python scripts/harrier_scaling_bench.py`._

--- a/SentenceTransformers.Benchmark/HARRIER-SCALING.md
+++ b/SentenceTransformers.Benchmark/HARRIER-SCALING.md
@@ -17,16 +17,17 @@ ONNX Q4F16 (`model_q4f16`) and Int8 (`model_quantized`, `MatMulNBits` + fused `G
 
 | Tokens | Pure fp32 | Pure Int8 | ONNX Q4F16 | ONNX Int8 | Pure Int8 / ONNX Int8 |
 |-------:|----------:|----------:|-----------:|----------:|----------------------:|
-|    128 |     419.5 |   **107.8** |      106.0 |     141.7 | **0.76× (pure wins)** |
-|    256 |     742.5 |   **202.9** |      208.1 |     219.5 | **0.92× (pure wins)** |
-|    512 |   1,598.3 |     518.0 |      451.3 |     363.2 | 1.43× |
-|  1,024 |   4,043.1 |   1,160.6 |      996.2 |     794.7 | 1.46× |
-|  2,048 |   9,170.4 |   2,883.0 |    2,414.1 |   1,889.8 | 1.53× |
-|  4,096 |  21,248.6 |   7,925.6 |    6,872.4 |   5,194.8 | 1.53× |
+|    128 |     360.9 |   **102.8** |       97.6 |     141.7 | **0.73× (pure wins)** |
+|    256 |     717.0 |   **187.9** |      189.1 |     200.4 | **0.94× (pure wins)** |
+|    512 |   1,496.0 |     404.4 |      374.9 |     347.6 | 1.16× |
+|  1,024 |   3,618.5 |     930.7 |      830.8 |     698.8 | 1.33× |
+|  2,048 |   8,098.5 |   2,225.5 |    2,099.6 |   1,774.6 | 1.25× |
+|  4,096 |  18,525.6 |   5,501.4 |    5,824.8 |   4,852.8 | 1.13× |
 
-Pure Int8 now beats ONNX Int8 up to 256 tokens and the long-context gap is ~1.5×. The Pure-Int8 column
-includes int8/VNNI attention scores (§2) and 512-bit AVX-512 kernels (§3). _(Absolute ms vary with this
-shared cloud box's load between runs; the controlled comparisons below toggle one variable at a time.)_
+Pure Int8 now beats ONNX Int8 up to 256 tokens, **beats ONNX Q4F16 at 4096** (5,501 vs 5,825), and is
+within **1.13–1.33×** of ONNX Int8 across mid/long contexts. The Pure-Int8 column includes int8/VNNI
+attention scores (§2), AVX-512 512-bit kernels (§3), and the register-blocked value GEMM (§4). _(Absolute
+ms vary with this shared cloud box's load between runs; controlled comparisons below toggle one variable.)_
 
 ## What was optimized (and the journey)
 
@@ -99,10 +100,23 @@ Controlled toggle (`DOTNET_EnableAVX512=0` vs default, same box, Int8, 4 cores),
 (attention 4096: 4,568→3,990 ms; int8 projections 4096: 2,367→1,551 ms.) AVX-512 has a small fixed
 overhead/downclock that shows at very short sequences but wins clearly from ~1k tokens up.
 
+### 4. Register-blocked value GEMM — the biggest attention win
+The value matmul `O = P·V` was rank-1 updates (per key: broadcast the head probabilities and FMA into the
+head accumulators), so each head's `headDim` accumulator was re-read and re-written **once per key**. It is
+now a **register-blocked GEMM**: a 4-head × 64-column output tile is held in **16 zmm accumulators** across
+the whole key chunk and written back to memory **once per tile** instead of once per key — the per-key acc
+read-modify-write was the bottleneck. This roughly **halved attention**:
+
+| attention ms (Int8, 4 cores) | 512 | 2048 | 4096 |
+|---|--:|--:|--:|
+| rank-1 value (AVX-512) | 147 | 1,117 | 3,990 |
+| **blocked value GEMM** | **94** | **601** | **2,096** |
+
 ### Net effect (Pure Int8)
-single-threaded original → max cores + vectorized GeGLU + head-fused block-flash + int8/VNNI scores +
-AVX-512: roughly **6–8× faster** end-to-end (exact factor drifts with the shared box's load), and the
-Int8/ONNX-Int8 gap went from ~2.0× to **~1.5× at 4096, with pure faster at ≤256 tokens**.
+The attention term went from ~10,500 ms (naive) to **~2,100 ms** at 4096 (block-flash + int8/VNNI scores +
+AVX-512 + blocked value GEMM ≈ **5× on attention**), and end-to-end Pure Int8 is now within **1.13× of
+ONNX Int8 at 4096** (was ~2.0×), **faster than ONNX Q4F16 at 4096**, and **faster than ONNX Int8 at
+≤256 tokens**.
 
 ## Long-context scaling (→ 32768, the full context window) — pure Int8 vs ONNX Int8
 
@@ -125,13 +139,19 @@ Two findings here:
    memory and completes.
 
 ## Honest parity assessment
-- **Short contexts (≤256 tokens): pure Int8 is now faster than ONNX Int8** (128: 0.76×, 256: 0.92×).
-- **Mid contexts (512–4k): ~1.4–1.5× off**, narrowed from ~2.0× by int8/VNNI scores + AVX-512. The
-  residual is the fp32 value matmul and ONNX's MLAS-class kernels. The next lever is an MLAS-style packed
-  GEMM for the value matmul (int8 value did not help — V is cache-resident, see §2).
-- **Long contexts (8k–32k): the gap *narrows* further (to ~1.24×) and pure is strictly more scalable in
-  memory** — it is the only one of the two that completes a 32768-token encode on this machine
-  (ONNX OOMs materializing the full score tensor).
+- **Short contexts (≤256 tokens): pure Int8 is faster than ONNX Int8** (128: 0.73×, 256: 0.94×) and ties
+  ONNX Q4F16.
+- **Mid/long contexts (512–4k): within 1.13–1.33×** of ONNX Int8 (was ~2.0×), and **faster than ONNX
+  Q4F16 at 4096**. Essentially at parity — the small residual is the fp32 value/softmax vs ONNX's MLAS
+  kernels. (int8 *value* was tried and reverted — V is cache-resident, see §2.)
+- **Long contexts (8k–32k): the gap narrows further (~1.2×) and pure is strictly more scalable in memory**
+  — it is the only one of the two that completes a 32768-token encode on this machine (ONNX OOMs
+  materializing the full score tensor).
+
+Net: pure Int8 went from ~2× off ONNX Int8 to **≤1.13–1.33× across all lengths, faster at short contexts,
+faster than ONNX Q4F16 at 4096, and the only build that runs the full 32768 window** — effectively at
+parity, achieved entirely in portable managed code (the 512-bit kernels degrade gracefully to 256-bit/
+`Vector<T>` on lesser hardware).
 
 ## Reproduce
 ```

--- a/SentenceTransformers.Benchmark/HarrierScalingBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierScalingBench.cs
@@ -1,0 +1,199 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using SentenceTransformers;
+
+/// <summary>
+/// Token-count scalability sweep for Harrier Small. Drives the SAME calibrated input strings
+/// (one per target sequence length, including the &lt;bos&gt;/&lt;eos&gt; specials) through the public
+/// end-to-end <c>EncodeAsync</c> path of both the pure-C# reimplementation and the ONNX build, and
+/// records wall-clock per encode at 128 / 256 / 512 / 1024 / 2048 / 4096 tokens.
+///
+/// The calibrated inputs (and the measured token counts) are written to a JSON file so the Python
+/// sentence-transformers harness can replay byte-identical text and produce a directly comparable
+/// third column. Because all three share the same Gemma BPE tokenizer, the per-target token counts
+/// line up across implementations.
+/// </summary>
+public static class HarrierScalingBench
+{
+    private static readonly int[] Targets = { 128, 256, 512, 1024, 2048, 4096 };
+
+    // Deterministic, content-agnostic word pool. The model's cost depends on sequence length, not on
+    // which tokens appear, so a repeated pool is fine and keeps the input reproducible.
+    private static readonly string[] Pool =
+    {
+        "curiosity", "mosaik", "search", "embedding", "vector", "database", "ranking", "hybrid",
+        "context", "token", "runtime", "inference", "latency", "throughput", "quantization",
+        "semantic", "retrieval", "document", "chunk", "pipeline", "provider", "benchmark",
+        "scalability", "transformer", "attention", "encoder", "multilingual", "normalize",
+    };
+
+    public static async Task RunAsync()
+    {
+        Console.WriteLine($"Harrier Small token-count scalability sweep (ProcessorCount={Environment.ProcessorCount})");
+        Console.WriteLine($"Targets (tokens incl. <bos>/<eos>): {string.Join(", ", Targets)}");
+        Console.WriteLine();
+
+        // ---- 1. Load the pure encoder; use its tokenizer to calibrate the input strings. ----
+        Console.WriteLine("Loading Harrier.Small.Pure (fp32) ...");
+        using var pure = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
+            quantization: SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None,
+            reportProgress: Progress("pure-weights"));
+        Console.WriteLine();
+
+        int CountTokens(string s) => pure.Tokenizer.Encode(new[] { s })[0].InputIds.Length;
+
+        var inputs = new List<(int Target, int Tokens, string Text)>();
+        foreach (var target in Targets)
+        {
+            var (text, tokens) = Calibrate(CountTokens, target);
+            inputs.Add((target, tokens, text));
+            Console.WriteLine($"  calibrated target {target,5} -> {tokens,5} tokens ({text.Length} chars)");
+        }
+        Console.WriteLine();
+
+        // Persist the calibrated inputs so the Python harness replays identical text.
+        var inputsPath = "/tmp/harrier_scaling_inputs.json";
+        await File.WriteAllTextAsync(inputsPath, JsonSerializer.Serialize(
+            inputs.Select(i => new { target = i.Target, tokens = i.Tokens, text = i.Text }),
+            new JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine($"Wrote calibrated inputs -> {inputsPath}");
+        Console.WriteLine();
+
+        // ---- 2. Time the pure encoder at each token count. ----
+        var pureMs = new double[inputs.Count];
+        Console.WriteLine("=== Harrier.Small.Pure (fp32) ===");
+        for (int i = 0; i < inputs.Count; i++)
+        {
+            pureMs[i] = await TimeEncodeAsync(s => pure.EncodeAsync(s), inputs[i].Text, inputs[i].Tokens);
+        }
+        Console.WriteLine();
+
+        // ---- 3. Time the ONNX encoder (default Q4F16) at each token count. ----
+        var onnxMs = new double[inputs.Count];
+        bool onnxOk = true;
+        try
+        {
+            Console.WriteLine("Loading Harrier.Small (ONNX Q4F16) ...");
+            using var onnx = await SentenceTransformers.Harrier.Small.SentenceEncoder.CreateAsync(
+                reportProgress: Progress("onnx-weights"));
+            Console.WriteLine();
+            Console.WriteLine("=== Harrier.Small (ONNX Q4F16) ===");
+            for (int i = 0; i < inputs.Count; i++)
+            {
+                onnxMs[i] = await TimeEncodeAsync(s => onnx.EncodeAsync(s), inputs[i].Text, inputs[i].Tokens);
+            }
+        }
+        catch (Exception ex)
+        {
+            onnxOk = false;
+            Console.WriteLine($"ONNX run failed: {ex.Message}");
+        }
+        Console.WriteLine();
+
+        // ---- 4. Summary table + machine-readable results for merging with Python. ----
+        Console.WriteLine("=== Scalability: elapsed ms per encode vs token count ===");
+        Console.WriteLine($"{"Tokens",8} | {"Pure fp32 (ms)",16} | {"ONNX Q4F16 (ms)",16}");
+        Console.WriteLine(new string('-', 50));
+        for (int i = 0; i < inputs.Count; i++)
+        {
+            var onnxCell = onnxOk ? onnxMs[i].ToString("n1") : "n/a";
+            Console.WriteLine($"{inputs[i].Tokens,8} | {pureMs[i],16:n1} | {onnxCell,16}");
+        }
+
+        var resultsPath = "/tmp/harrier_scaling_csharp.json";
+        await File.WriteAllTextAsync(resultsPath, JsonSerializer.Serialize(
+            inputs.Select((inp, i) => new
+            {
+                target = inp.Target,
+                tokens = inp.Tokens,
+                pure_ms = pureMs[i],
+                onnx_ms = onnxOk ? (double?)onnxMs[i] : null,
+            }),
+            new JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine();
+        Console.WriteLine($"Wrote C# results -> {resultsPath}");
+    }
+
+    /// <summary>Warms up once, then times the median over an iteration count that shrinks as the
+    /// sequence (and therefore the per-encode cost) grows, so the large-N points stay affordable.</summary>
+    private static async Task<double> TimeEncodeAsync(Func<string[], Task<float[][]>> encode, string text, int tokens)
+    {
+        var batch = new[] { text };
+
+        // Warmup (also forces any lazy init / JIT on the hot path).
+        await encode(batch);
+
+        int iterations =
+            tokens <= 256  ? 7 :
+            tokens <= 512  ? 5 :
+            tokens <= 1024 ? 3 :
+            tokens <= 2048 ? 2 : 1;
+
+        var samples = new double[iterations];
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            await encode(batch);
+            sw.Stop();
+            samples[i] = sw.Elapsed.TotalMilliseconds;
+        }
+        Array.Sort(samples);
+        double median = samples[samples.Length / 2];
+        Console.WriteLine($"  {tokens,5} tokens: {median,9:n1} ms  (median of {iterations}, min {samples[0]:n1})");
+        return median;
+    }
+
+    /// <summary>
+    /// Builds a string whose tokenized length (including the &lt;bos&gt;/&lt;eos&gt; specials added by the
+    /// tokenizer) equals <paramref name="target"/>. Grows by whole pool words to get close, then tops up
+    /// with single-token fillers to land exactly on (or within one of) the target.
+    /// </summary>
+    private static (string Text, int Tokens) Calibrate(Func<string, int> countTokens, int target)
+    {
+        var sb = new StringBuilder();
+        int idx = 0;
+
+        while (true)
+        {
+            int prevLen = sb.Length;
+            if (sb.Length > 0) sb.Append(' ');
+            sb.Append(Pool[idx++ % Pool.Length]);
+            int c = countTokens(sb.ToString());
+            if (c >= target)
+            {
+                if (c == target) return (sb.ToString(), c);
+                sb.Length = prevLen; // overshoot: drop the last whole word and top up below
+                break;
+            }
+        }
+
+        // Top up with " a" (a single Gemma BPE token: metaspace + 'a') until we hit the target exactly.
+        while (true)
+        {
+            int prevLen = sb.Length;
+            sb.Append(" a");
+            int c = countTokens(sb.ToString());
+            if (c >= target)
+            {
+                if (c > target) sb.Length = prevLen; // can't land exactly; report the nearest under
+                break;
+            }
+        }
+        return (sb.ToString(), countTokens(sb.ToString()));
+    }
+
+    private static Action<DownloadProgress> Progress(string label)
+    {
+        int lastPct = -1;
+        return p =>
+        {
+            int pct = (int)(p.Fraction * 100);
+            if (pct != lastPct && pct % 10 == 0)
+            {
+                lastPct = pct;
+                Console.WriteLine($"  [{label}] {pct,3}%  ({p.DownloadedBytes / 1024 / 1024} MB)");
+            }
+        };
+    }
+}

--- a/SentenceTransformers.Benchmark/HarrierScalingBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierScalingBench.cs
@@ -18,6 +18,10 @@ public static class HarrierScalingBench
 {
     private static readonly int[] Targets = { 128, 256, 512, 1024, 2048, 4096 };
 
+    /// <summary>Drives the pure encoder on all cores (without changing the library's single-threaded
+    /// default) so its numbers are comparable to ONNX Runtime / PyTorch, which use every core.</summary>
+    private static ParallelOptions MaxCores => new() { MaxDegreeOfParallelism = Environment.ProcessorCount };
+
     // Deterministic, content-agnostic word pool. The model's cost depends on sequence length, not on
     // which tokens appear, so a repeated pool is fine and keeps the input reproducible.
     private static readonly string[] Pool =
@@ -60,45 +64,36 @@ public static class HarrierScalingBench
         Console.WriteLine($"Wrote calibrated inputs -> {inputsPath}");
         Console.WriteLine();
 
-        // ---- 2. Time the pure encoder at each token count. ----
-        var pureMs = new double[inputs.Count];
-        Console.WriteLine("=== Harrier.Small.Pure (fp32) ===");
-        for (int i = 0; i < inputs.Count; i++)
-        {
-            pureMs[i] = await TimeEncodeAsync(s => pure.EncodeAsync(s), inputs[i].Text, inputs[i].Tokens);
-        }
-        Console.WriteLine();
+        var texts = inputs.Select(i => i.Text).ToArray();
+        var tokenCounts = inputs.Select(i => i.Tokens).ToArray();
 
-        // ---- 3. Time the ONNX encoder (default Q4F16) at each token count. ----
-        var onnxMs = new double[inputs.Count];
-        bool onnxOk = true;
-        try
+        // ---- 2. Pure encoder (fp32 + Int8), run on all cores for a fair architectural comparison. ----
+        var pureFp32 = await TimeColumnAsync("Harrier.Small.Pure (fp32)",
+            s => pure.EncodeAsync(s, MaxCores), texts, tokenCounts);
+
+        Console.WriteLine("Loading Harrier.Small.Pure (Int8) ...");
+        double[] pureInt8;
+        using (var pureQ = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
+                   quantization: SentenceTransformers.Harrier.Small.Pure.Model.Quantization.Int8))
         {
-            Console.WriteLine("Loading Harrier.Small (ONNX Q4F16) ...");
-            using var onnx = await SentenceTransformers.Harrier.Small.SentenceEncoder.CreateAsync(
-                reportProgress: Progress("onnx-weights"));
-            Console.WriteLine();
-            Console.WriteLine("=== Harrier.Small (ONNX Q4F16) ===");
-            for (int i = 0; i < inputs.Count; i++)
-            {
-                onnxMs[i] = await TimeEncodeAsync(s => onnx.EncodeAsync(s), inputs[i].Text, inputs[i].Tokens);
-            }
+            pureInt8 = await TimeColumnAsync("Harrier.Small.Pure (Int8)",
+                s => pureQ.EncodeAsync(s, MaxCores), texts, tokenCounts);
         }
-        catch (Exception ex)
-        {
-            onnxOk = false;
-            Console.WriteLine($"ONNX run failed: {ex.Message}");
-        }
-        Console.WriteLine();
+
+        // ---- 3. ONNX encoder (Q4F16 default + Int8 'quantized' variant). ----
+        var onnxQ4 = await TimeOnnxAsync("Harrier.Small (ONNX Q4F16)", texts, tokenCounts,
+            modelUrl: null, dataUrl: null);
+        var onnxInt8 = await TimeOnnxAsync("Harrier.Small (ONNX Int8)", texts, tokenCounts,
+            modelUrl: SentenceTransformers.Harrier.Small.SentenceEncoder.Quantizations.QuantizedModelUrl,
+            dataUrl: SentenceTransformers.Harrier.Small.SentenceEncoder.Quantizations.QuantizedModelDataUrl);
 
         // ---- 4. Summary table + machine-readable results for merging with Python. ----
-        Console.WriteLine("=== Scalability: elapsed ms per encode vs token count ===");
-        Console.WriteLine($"{"Tokens",8} | {"Pure fp32 (ms)",16} | {"ONNX Q4F16 (ms)",16}");
-        Console.WriteLine(new string('-', 50));
+        Console.WriteLine("=== Scalability: elapsed ms per encode vs token count (all on max cores) ===");
+        Console.WriteLine($"{"Tokens",8} | {"Pure fp32",12} | {"Pure Int8",12} | {"ONNX Q4F16",12} | {"ONNX Int8",12}");
+        Console.WriteLine(new string('-', 70));
         for (int i = 0; i < inputs.Count; i++)
         {
-            var onnxCell = onnxOk ? onnxMs[i].ToString("n1") : "n/a";
-            Console.WriteLine($"{inputs[i].Tokens,8} | {pureMs[i],16:n1} | {onnxCell,16}");
+            Console.WriteLine($"{tokenCounts[i],8} | {pureFp32[i],12:n1} | {pureInt8[i],12:n1} | {Cell(onnxQ4, i),12} | {Cell(onnxInt8, i),12}");
         }
 
         var resultsPath = "/tmp/harrier_scaling_csharp.json";
@@ -107,12 +102,53 @@ public static class HarrierScalingBench
             {
                 target = inp.Target,
                 tokens = inp.Tokens,
-                pure_ms = pureMs[i],
-                onnx_ms = onnxOk ? (double?)onnxMs[i] : null,
+                pure_fp32_ms = pureFp32[i],
+                pure_int8_ms = pureInt8[i],
+                onnx_q4f16_ms = onnxQ4?[i],
+                onnx_int8_ms = onnxInt8?[i],
             }),
             new JsonSerializerOptions { WriteIndented = true }));
         Console.WriteLine();
         Console.WriteLine($"Wrote C# results -> {resultsPath}");
+
+        static string Cell(double[] col, int i) => col is null ? "n/a" : col[i].ToString("n1");
+    }
+
+    private static async Task<double[]> TimeColumnAsync(string label, Func<string[], Task<float[][]>> encode, string[] texts, int[] tokens)
+    {
+        Console.WriteLine($"=== {label} ===");
+        var ms = new double[texts.Length];
+        for (int i = 0; i < texts.Length; i++)
+        {
+            ms[i] = await TimeEncodeAsync(encode, texts[i], tokens[i]);
+        }
+        Console.WriteLine();
+        return ms;
+    }
+
+    /// <summary>Downloads (if needed) and times an ONNX variant; returns null if it cannot be loaded.
+    /// ONNX Runtime uses every core by default, so no ParallelOptions plumbing is needed here.</summary>
+    private static async Task<double[]> TimeOnnxAsync(string label, string[] texts, int[] tokens, string modelUrl, string dataUrl)
+    {
+        try
+        {
+            Console.WriteLine($"Loading {label} ...");
+            using var onnx = await SentenceTransformers.Harrier.Small.SentenceEncoder.CreateAsync(
+                modelUrl: modelUrl,
+                modelDataUrl: dataUrl,
+                downloadToPath: modelUrl is null
+                    ? null
+                    : Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small.Int8", "model.onnx"),
+                reportProgress: Progress("onnx-weights"));
+            Console.WriteLine();
+            return await TimeColumnAsync(label, s => onnx.EncodeAsync(s), texts, tokens);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"{label} failed: {ex.Message}");
+            Console.WriteLine();
+            return null;
+        }
     }
 
     /// <summary>
@@ -144,7 +180,7 @@ public static class HarrierScalingBench
         Console.WriteLine($"=== Harrier.Small.Pure ({quant}) ===");
         for (int i = 0; i < inputs.Count; i++)
         {
-            ms[i] = await TimeEncodeAsync(s => pure.EncodeAsync(s), inputs[i].Text, inputs[i].Tokens);
+            ms[i] = await TimeEncodeAsync(s => pure.EncodeAsync(s, MaxCores), inputs[i].Text, inputs[i].Tokens);
         }
 
         var resultsPath = $"/tmp/harrier_scaling_pure_{quant}.json";
@@ -154,6 +190,68 @@ public static class HarrierScalingBench
         Console.WriteLine();
         Console.WriteLine($"Wrote results -> {resultsPath}");
     }
+
+    /// <summary>
+    /// Correctness gate: encodes the 5 multilingual reference sentences with the pure encoder (fp32 and
+    /// Int8) and compares each embedding to the PyTorch golden reference via cosine similarity. Also
+    /// writes the pure embeddings to <c>/tmp/harrier_verify_{quant}_{tag}.json</c> so a before/after run
+    /// can confirm an optimization did not move the output beyond float-reassociation noise.
+    /// </summary>
+    public static async Task RunVerifyAsync(string tag)
+    {
+        // The golden reference lives in the test project's Resources.
+        string[] candidates =
+        {
+            Path.Combine(AppContext.BaseDirectory, "harrier-small-reference.json"),
+            "/home/user/sentence-transformers-sharp/SentenceTransformers.Test/Resources/harrier-small-reference.json",
+        };
+        var refPath = candidates.FirstOrDefault(File.Exists);
+        if (refPath is null)
+        {
+            Console.WriteLine($"Reference JSON not found (looked in: {string.Join(", ", candidates)}).");
+            return;
+        }
+
+        using var refDoc = JsonDocument.Parse(await File.ReadAllTextAsync(refPath));
+        var sentences = refDoc.RootElement.GetProperty("sentences").EnumerateArray().Select(e => e.GetString()!).ToArray();
+        var golden = refDoc.RootElement.GetProperty("embeddings").EnumerateArray()
+            .Select(row => row.EnumerateArray().Select(x => x.GetSingle()).ToArray()).ToArray();
+
+        foreach (var quant in new[]
+        {
+            SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None,
+            SentenceTransformers.Harrier.Small.Pure.Model.Quantization.Int8,
+        })
+        {
+            using var enc = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(quantization: quant);
+            var emb = await enc.EncodeAsync(sentences, MaxCores);
+
+            Console.WriteLine($"=== verify {quant} ({tag}) vs PyTorch golden ===");
+            double minCos = 1.0, sumCos = 0;
+            for (int i = 0; i < sentences.Length; i++)
+            {
+                double cos = Cosine(emb[i], golden[i]);
+                minCos = Math.Min(minCos, cos);
+                sumCos += cos;
+                Console.WriteLine($"  sent[{i}] cos(golden) = {cos:F6}  | {Trim(sentences[i])}");
+            }
+            Console.WriteLine($"  min={minCos:F6} avg={sumCos / sentences.Length:F6}");
+            Console.WriteLine();
+
+            var outPath = $"/tmp/harrier_verify_{quant}_{tag}.json";
+            await File.WriteAllTextAsync(outPath, JsonSerializer.Serialize(
+                emb.Select(v => v.Select(x => (double)x).ToArray()).ToArray()));
+        }
+    }
+
+    private static double Cosine(float[] a, float[] b)
+    {
+        double dot = 0, na = 0, nb = 0;
+        for (int i = 0; i < a.Length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+        return dot / (Math.Sqrt(na) * Math.Sqrt(nb) + 1e-12);
+    }
+
+    private static string Trim(string s) => s.Length <= 28 ? s : s.Substring(0, 28) + "…";
 
     /// <summary>
     /// Per-stage profile of the pure fp32 forward pass at a few sequence lengths, at a chosen degree of

--- a/SentenceTransformers.Benchmark/HarrierScalingBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierScalingBench.cs
@@ -244,6 +244,53 @@ public static class HarrierScalingBench
         }
     }
 
+    /// <summary>Correctness gate for the FMA fast path: encodes a long (full-block) text both with the
+    /// FMA tiled attention and with the portable head-fused path forced, and reports their agreement.
+    /// The FMA path is only taken for full 8-query blocks, so this needs a sequence of &gt;= ~64 tokens.</summary>
+    public static async Task RunVerifyFmaAsync()
+    {
+        const string inputsPath = "/tmp/harrier_scaling_inputs.json";
+        var texts = new List<string>();
+        if (File.Exists(inputsPath))
+        {
+            using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(inputsPath));
+            texts.AddRange(doc.RootElement.EnumerateArray().Select(e => e.GetProperty("text").GetString()!));
+        }
+        else
+        {
+            texts.Add(string.Join(' ', Enumerable.Range(0, 600).Select(i => Pool[i % Pool.Length])));
+        }
+
+        foreach (var quant in new[]
+        {
+            SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None,
+            SentenceTransformers.Harrier.Small.Pure.Model.Quantization.Int8,
+        })
+        {
+            using var enc = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(quantization: quant);
+
+            SentenceTransformers.Harrier.Small.Pure.Model.ForwardProfile.ForcePortableAttention = true;
+            var portable = await enc.EncodeAsync(texts.ToArray(), MaxCores);
+            SentenceTransformers.Harrier.Small.Pure.Model.ForwardProfile.ForcePortableAttention = false;
+            var fma = await enc.EncodeAsync(texts.ToArray(), MaxCores);
+
+            Console.WriteLine($"=== FMA vs portable attention, {quant} ===");
+            double minCos = 1.0, maxAbs = 0;
+            for (int i = 0; i < portable.Length; i++)
+            {
+                double cos = Cosine(portable[i], fma[i]);
+                for (int d = 0; d < portable[i].Length; d++)
+                {
+                    maxAbs = Math.Max(maxAbs, Math.Abs(portable[i][d] - fma[i][d]));
+                }
+                minCos = Math.Min(minCos, cos);
+                Console.WriteLine($"  text[{i}] ({texts[i].Length,6} chars) cos(portable,fma) = {cos:F8}");
+            }
+            Console.WriteLine($"  min cos = {minCos:F8}, max|Δ| = {maxAbs:E3}");
+            Console.WriteLine();
+        }
+    }
+
     private static double Cosine(float[] a, float[] b)
     {
         double dot = 0, na = 0, nb = 0;

--- a/SentenceTransformers.Benchmark/HarrierScalingBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierScalingBench.cs
@@ -114,6 +114,82 @@ public static class HarrierScalingBench
         static string Cell(double[] col, int i) => col is null ? "n/a" : col[i].ToString("n1");
     }
 
+    /// <summary>
+    /// Long-context sweep (pure Int8 vs ONNX Int8) at large token counts up to the model's 32768 context
+    /// window, with big intervals. Inputs are generated to a target word count and the actual token count
+    /// (capped at the context window) is reported. Times a single encode per point (the O(n^2) attention
+    /// makes repeats impractical at 32768) on all cores.
+    /// </summary>
+    public static async Task RunLongAsync()
+    {
+        int[] targets = { 4096, 8192, 16384, 32768 };
+
+        Console.WriteLine($"Harrier Small long-context sweep (ProcessorCount={Environment.ProcessorCount})");
+        var texts = targets.Select(t => string.Join(' ', Enumerable.Range(0, (int)(t * 1.1)).Select(i => Pool[i % Pool.Length]))).ToArray();
+
+        Console.WriteLine("Loading Harrier.Small.Pure (Int8) ...");
+        using var pure = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
+            quantization: SentenceTransformers.Harrier.Small.Pure.Model.Quantization.Int8);
+        var tok = targets.Select((t, i) => Math.Min(pure.Tokenizer.Encode(new[] { texts[i] })[0].InputIds.Length, pure.MaxChunkLength)).ToArray();
+        Console.WriteLine($"Actual token counts: {string.Join(", ", tok)}");
+        Console.WriteLine();
+
+        var pureMs = new double[targets.Length];
+        Console.WriteLine("=== Harrier.Small.Pure (Int8) ===");
+        for (int i = 0; i < targets.Length; i++)
+        {
+            pureMs[i] = await TimeOnceAsync(s => pure.EncodeAsync(s, MaxCores), texts[i], tok[i], warmup: i == 0);
+        }
+        Console.WriteLine();
+
+        var onnxMs = new double[targets.Length];
+        try
+        {
+            Console.WriteLine("Loading Harrier.Small (ONNX Int8) ...");
+            using var onnx = await SentenceTransformers.Harrier.Small.SentenceEncoder.CreateAsync(
+                modelUrl: SentenceTransformers.Harrier.Small.SentenceEncoder.Quantizations.QuantizedModelUrl,
+                modelDataUrl: SentenceTransformers.Harrier.Small.SentenceEncoder.Quantizations.QuantizedModelDataUrl,
+                downloadToPath: Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small.Int8", "model.onnx"));
+            Console.WriteLine();
+            Console.WriteLine("=== Harrier.Small (ONNX Int8) ===");
+            for (int i = 0; i < targets.Length; i++)
+            {
+                onnxMs[i] = await TimeOnceAsync(s => onnx.EncodeAsync(s), texts[i], tok[i], warmup: i == 0);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"ONNX Int8 failed: {ex.Message}");
+        }
+        Console.WriteLine();
+
+        Console.WriteLine("=== Long-context: ms per encode (max cores) ===");
+        Console.WriteLine($"{"Tokens",8} | {"Pure Int8",12} | {"ONNX Int8",12} | {"ratio",6}");
+        Console.WriteLine(new string('-', 46));
+        for (int i = 0; i < targets.Length; i++)
+        {
+            string ratio = onnxMs[i] > 0 ? (pureMs[i] / onnxMs[i]).ToString("n2") + "x" : "n/a";
+            Console.WriteLine($"{tok[i],8} | {pureMs[i],12:n1} | {onnxMs[i],12:n1} | {ratio,6}");
+        }
+
+        await File.WriteAllTextAsync("/tmp/harrier_scaling_long.json", JsonSerializer.Serialize(
+            targets.Select((t, i) => new { target = t, tokens = tok[i], pure_int8_ms = pureMs[i], onnx_int8_ms = onnxMs[i] }),
+            new JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine();
+        Console.WriteLine("Wrote /tmp/harrier_scaling_long.json");
+    }
+
+    private static async Task<double> TimeOnceAsync(Func<string[], Task<float[][]>> encode, string text, int tokens, bool warmup)
+    {
+        var batch = new[] { text };
+        if (warmup) await encode(batch);
+        var sw = Stopwatch.StartNew();
+        await encode(batch);
+        sw.Stop();
+        Console.WriteLine($"  {tokens,6} tokens: {sw.Elapsed.TotalMilliseconds,12:n1} ms");
+        return sw.Elapsed.TotalMilliseconds;
+    }
+
     private static async Task<double[]> TimeColumnAsync(string label, Func<string[], Task<float[][]>> encode, string[] texts, int[] tokens)
     {
         Console.WriteLine($"=== {label} ===");

--- a/SentenceTransformers.Benchmark/HarrierScalingBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierScalingBench.cs
@@ -257,7 +257,7 @@ public static class HarrierScalingBench
     /// Per-stage profile of the pure fp32 forward pass at a few sequence lengths, at a chosen degree of
     /// parallelism. Shows which stages scale linearly (projection matmuls) vs quadratically (attention).
     /// </summary>
-    public static async Task RunProfileAsync(int maxDop)
+    public static async Task RunProfileAsync(int maxDop, SentenceTransformers.Harrier.Small.Pure.Model.Quantization quant = SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None)
     {
         const string inputsPath = "/tmp/harrier_scaling_inputs.json";
         if (!File.Exists(inputsPath))
@@ -270,9 +270,8 @@ public static class HarrierScalingBench
         var byTokens = docp.RootElement.EnumerateArray()
             .ToDictionary(e => e.GetProperty("tokens").GetInt32(), e => e.GetProperty("text").GetString()!);
 
-        Console.WriteLine($"Loading Harrier.Small.Pure (fp32) for profiling (MaxDop={maxDop}) ...");
-        using var pure = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
-            quantization: SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None);
+        Console.WriteLine($"Loading Harrier.Small.Pure ({quant}) for profiling (MaxDop={maxDop}) ...");
+        using var pure = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(quantization: quant);
         Console.WriteLine();
 
         var po = new ParallelOptions { MaxDegreeOfParallelism = maxDop };

--- a/SentenceTransformers.Benchmark/HarrierScalingBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierScalingBench.cs
@@ -115,6 +115,46 @@ public static class HarrierScalingBench
         Console.WriteLine($"Wrote C# results -> {resultsPath}");
     }
 
+    /// <summary>
+    /// Re-runs only the pure encoder at a chosen weight precision, replaying the byte-identical
+    /// calibrated inputs persisted by <see cref="RunAsync"/> (so it lines up with the existing
+    /// fp32 / ONNX / Python columns without recalibrating). Writes <c>/tmp/harrier_scaling_pure_{quant}.json</c>.
+    /// </summary>
+    public static async Task RunPureQuantAsync(SentenceTransformers.Harrier.Small.Pure.Model.Quantization quant)
+    {
+        const string inputsPath = "/tmp/harrier_scaling_inputs.json";
+        if (!File.Exists(inputsPath))
+        {
+            Console.WriteLine($"Calibrated inputs not found at {inputsPath}; run 'harrier-scaling' first.");
+            return;
+        }
+
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(inputsPath));
+        var inputs = doc.RootElement.EnumerateArray()
+            .Select(e => (Tokens: e.GetProperty("tokens").GetInt32(), Text: e.GetProperty("text").GetString()!))
+            .ToList();
+
+        Console.WriteLine($"Loading Harrier.Small.Pure ({quant}) ... (ProcessorCount={Environment.ProcessorCount})");
+        using var pure = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
+            quantization: quant,
+            reportProgress: Progress("pure-weights"));
+        Console.WriteLine();
+
+        var ms = new double[inputs.Count];
+        Console.WriteLine($"=== Harrier.Small.Pure ({quant}) ===");
+        for (int i = 0; i < inputs.Count; i++)
+        {
+            ms[i] = await TimeEncodeAsync(s => pure.EncodeAsync(s), inputs[i].Text, inputs[i].Tokens);
+        }
+
+        var resultsPath = $"/tmp/harrier_scaling_pure_{quant}.json";
+        await File.WriteAllTextAsync(resultsPath, JsonSerializer.Serialize(
+            inputs.Select((inp, i) => new { tokens = inp.Tokens, pure_ms = ms[i] }),
+            new JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine();
+        Console.WriteLine($"Wrote results -> {resultsPath}");
+    }
+
     /// <summary>Warms up once, then times the median over an iteration count that shrinks as the
     /// sequence (and therefore the per-encode cost) grows, so the large-N points stay affordable.</summary>
     private static async Task<double> TimeEncodeAsync(Func<string[], Task<float[][]>> encode, string text, int tokens)

--- a/SentenceTransformers.Benchmark/HarrierScalingBench.cs
+++ b/SentenceTransformers.Benchmark/HarrierScalingBench.cs
@@ -155,6 +155,49 @@ public static class HarrierScalingBench
         Console.WriteLine($"Wrote results -> {resultsPath}");
     }
 
+    /// <summary>
+    /// Per-stage profile of the pure fp32 forward pass at a few sequence lengths, at a chosen degree of
+    /// parallelism. Shows which stages scale linearly (projection matmuls) vs quadratically (attention).
+    /// </summary>
+    public static async Task RunProfileAsync(int maxDop)
+    {
+        const string inputsPath = "/tmp/harrier_scaling_inputs.json";
+        if (!File.Exists(inputsPath))
+        {
+            Console.WriteLine($"Calibrated inputs not found at {inputsPath}; run 'harrier-scaling' first.");
+            return;
+        }
+
+        using var docp = JsonDocument.Parse(await File.ReadAllTextAsync(inputsPath));
+        var byTokens = docp.RootElement.EnumerateArray()
+            .ToDictionary(e => e.GetProperty("tokens").GetInt32(), e => e.GetProperty("text").GetString()!);
+
+        Console.WriteLine($"Loading Harrier.Small.Pure (fp32) for profiling (MaxDop={maxDop}) ...");
+        using var pure = await SentenceTransformers.Harrier.Small.Pure.SentenceEncoder.CreateAsync(
+            quantization: SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None);
+        Console.WriteLine();
+
+        var po = new ParallelOptions { MaxDegreeOfParallelism = maxDop };
+
+        foreach (var tokens in new[] { 512, 2048, 4096 })
+        {
+            if (!byTokens.TryGetValue(tokens, out var text)) continue;
+            var batch = new[] { text };
+
+            // Warmup with profiling off.
+            SentenceTransformers.Harrier.Small.Pure.Model.ForwardProfile.Enabled = false;
+            await pure.EncodeAsync(batch, po);
+
+            // One profiled encode.
+            SentenceTransformers.Harrier.Small.Pure.Model.ForwardProfile.Reset();
+            SentenceTransformers.Harrier.Small.Pure.Model.ForwardProfile.Enabled = true;
+            await pure.EncodeAsync(batch, po);
+            SentenceTransformers.Harrier.Small.Pure.Model.ForwardProfile.Enabled = false;
+            SentenceTransformers.Harrier.Small.Pure.Model.ForwardProfile.Report($"{tokens} tokens, MaxDop={maxDop}");
+            Console.WriteLine();
+        }
+    }
+
     /// <summary>Warms up once, then times the median over an iteration count that shrinks as the
     /// sequence (and therefore the per-encode cost) grows, so the large-N points stay affordable.</summary>
     private static async Task<double> TimeEncodeAsync(Func<string[], Task<float[][]>> encode, string text, int tokens)

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -31,6 +31,15 @@ if (args.Length > 0 && args[0] == "harrier-scaling")
     return;
 }
 
+if (args.Length > 0 && args[0] == "harrier-scaling-pure")
+{
+    var quant = args.Length > 1
+        ? Enum.Parse<SentenceTransformers.Harrier.Small.Pure.Model.Quantization>(args[1], ignoreCase: true)
+        : SentenceTransformers.Harrier.Small.Pure.Model.Quantization.Int8;
+    await HarrierScalingBench.RunPureQuantAsync(quant);
+    return;
+}
+
 // ---- Build a few-paragraph input dataset ----
 var texts = new[]
 {

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -38,6 +38,12 @@ if (args.Length > 0 && args[0] == "harrier-verify")
     return;
 }
 
+if (args.Length > 0 && args[0] == "harrier-scaling-long")
+{
+    await HarrierScalingBench.RunLongAsync();
+    return;
+}
+
 if (args.Length > 0 && args[0] == "harrier-verify-fma")
 {
     await HarrierScalingBench.RunVerifyFmaAsync();

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -31,6 +31,13 @@ if (args.Length > 0 && args[0] == "harrier-scaling")
     return;
 }
 
+if (args.Length > 0 && args[0] == "harrier-profile")
+{
+    int maxDop = args.Length > 1 ? int.Parse(args[1]) : 1;
+    await HarrierScalingBench.RunProfileAsync(maxDop);
+    return;
+}
+
 if (args.Length > 0 && args[0] == "harrier-scaling-pure")
 {
     var quant = args.Length > 1

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -25,6 +25,12 @@ if (args.Length > 0 && args[0] == "harrier-diag")
     return;
 }
 
+if (args.Length > 0 && args[0] == "harrier-scaling")
+{
+    await HarrierScalingBench.RunAsync();
+    return;
+}
+
 // ---- Build a few-paragraph input dataset ----
 var texts = new[]
 {

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -41,7 +41,10 @@ if (args.Length > 0 && args[0] == "harrier-verify")
 if (args.Length > 0 && args[0] == "harrier-profile")
 {
     int maxDop = args.Length > 1 ? int.Parse(args[1]) : 1;
-    await HarrierScalingBench.RunProfileAsync(maxDop);
+    var pquant = args.Length > 2
+        ? Enum.Parse<SentenceTransformers.Harrier.Small.Pure.Model.Quantization>(args[2], ignoreCase: true)
+        : SentenceTransformers.Harrier.Small.Pure.Model.Quantization.None;
+    await HarrierScalingBench.RunProfileAsync(maxDop, pquant);
     return;
 }
 

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -31,6 +31,13 @@ if (args.Length > 0 && args[0] == "harrier-scaling")
     return;
 }
 
+if (args.Length > 0 && args[0] == "harrier-verify")
+{
+    var tag = args.Length > 1 ? args[1] : "run";
+    await HarrierScalingBench.RunVerifyAsync(tag);
+    return;
+}
+
 if (args.Length > 0 && args[0] == "harrier-profile")
 {
     int maxDop = args.Length > 1 ? int.Parse(args[1]) : 1;

--- a/SentenceTransformers.Benchmark/Program.cs
+++ b/SentenceTransformers.Benchmark/Program.cs
@@ -38,6 +38,12 @@ if (args.Length > 0 && args[0] == "harrier-verify")
     return;
 }
 
+if (args.Length > 0 && args[0] == "harrier-verify-fma")
+{
+    await HarrierScalingBench.RunVerifyFmaAsync();
+    return;
+}
+
 if (args.Length > 0 && args[0] == "harrier-profile")
 {
     int maxDop = args.Length > 1 ? int.Parse(args[1]) : 1;

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/ForwardProfile.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/ForwardProfile.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+
+namespace SentenceTransformers.Harrier.Small.Pure.Model;
+
+/// <summary>
+/// Opt-in, very low-overhead per-stage timer for the pure forward pass, used to attribute encode time
+/// to the parts that scale linearly with the sequence length (the projection matmuls) versus the part
+/// that scales quadratically (self-attention). Disabled by default so it adds nothing to the hot path;
+/// set <see cref="Enabled"/> to start accumulating, then call <see cref="Report"/> to print and reset.
+/// </summary>
+public static class ForwardProfile
+{
+    public static bool Enabled;
+
+    // Stage -> accumulated stopwatch ticks. Insertion-ordered so the report reads top-to-bottom.
+    private static readonly System.Collections.Generic.Dictionary<string, long> _ticks = new();
+    private static readonly object _lock = new();
+
+    public static long Start() => Enabled ? Stopwatch.GetTimestamp() : 0L;
+
+    public static void Stop(string stage, long startTimestamp)
+    {
+        if (!Enabled) return;
+        long delta = Stopwatch.GetTimestamp() - startTimestamp;
+        lock (_lock)
+        {
+            _ticks.TryGetValue(stage, out var cur);
+            _ticks[stage] = cur + delta;
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock) { _ticks.Clear(); }
+    }
+
+    public static void Report(string header)
+    {
+        lock (_lock)
+        {
+            double toMs(long t) => t * 1000.0 / Stopwatch.Frequency;
+            long total = 0;
+            foreach (var v in _ticks.Values) total += v;
+
+            Console.WriteLine($"  -- {header} --");
+            foreach (var kv in _ticks)
+            {
+                double ms = toMs(kv.Value);
+                double pct = total > 0 ? 100.0 * kv.Value / total : 0;
+                Console.WriteLine($"     {kv.Key,-14} {ms,10:n1} ms  {pct,5:n1}%");
+            }
+            Console.WriteLine($"     {"TOTAL",-14} {toMs(total),10:n1} ms");
+        }
+    }
+}

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/ForwardProfile.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/ForwardProfile.cs
@@ -12,6 +12,10 @@ public static class ForwardProfile
 {
     public static bool Enabled;
 
+    /// <summary>Test/diagnostic switch: force the portable head-fused attention path even on x64, so the
+    /// FMA fast path can be compared against it for correctness. Not used in production.</summary>
+    public static bool ForcePortableAttention;
+
     // Stage -> accumulated stopwatch ticks. Insertion-ordered so the report reads top-to-bottom.
     private static readonly System.Collections.Generic.Dictionary<string, long> _ticks = new();
     private static readonly object _lock = new();

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -572,11 +572,7 @@ internal sealed class Gemma3Model
                 }
 
                 // Head-fused value: each value row is read once and accumulated into all 4 heads.
-                for (int jj = 0; jj < cnt; jj++)
-                {
-                    AxpyHeads4(sbuf[0 * KeyChunk + jj], sbuf[1 * KeyChunk + jj], sbuf[2 * KeyChunk + jj], sbuf[3 * KeyChunk + jj],
-                               v, (kb + jj) * kvStride, acc, accLocal, headDim);
-                }
+                AxpyHeads4Chunk(sbuf, cnt, kb, v, kvStride, acc, accLocal, headDim);
             }
         }
 
@@ -699,11 +695,7 @@ internal sealed class Gemma3Model
                     mState[st] = mNew;
                 }
 
-                for (int jj = 0; jj < cnt; jj++)
-                {
-                    AxpyHeads4(sbuf[0 * KeyChunk + jj], sbuf[1 * KeyChunk + jj], sbuf[2 * KeyChunk + jj], sbuf[3 * KeyChunk + jj],
-                               v, (kb + jj) * kvStride, acc, accLocal, headDim);
-                }
+                AxpyHeads4Chunk(sbuf, cnt, kb, v, kvStride, acc, accLocal, headDim);
             }
         }
 
@@ -873,6 +865,67 @@ internal sealed class Gemma3Model
             Unsafe.Add(ref orf, headDim + d)       += s1 * vd;
             Unsafe.Add(ref orf, 2 * headDim + d)   += s2 * vd;
             Unsafe.Add(ref orf, 3 * headDim + d)   += s3 * vd;
+        }
+    }
+
+    /// <summary>
+    /// Register-blocked value matmul for a whole key chunk: accumulates <c>O[head] += Σ_jj P[head,jj]·V[jj]</c>
+    /// for all four heads over the chunk's keys. On AVX-512 it keeps a 4-head × 64-column output tile in 16
+    /// zmm accumulators across the chunk so each head accumulator is written to memory once per tile instead
+    /// of once per key (the rank-1 <see cref="AxpyHeads4"/> path re-read/wrote acc every key). <paramref name="acc"/>
+    /// must already be rescaled by the online-softmax correction. Falls back to per-key <see cref="AxpyHeads4"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void AxpyHeads4Chunk(ReadOnlySpan<float> sbuf, int cnt, int kb, float[] v, int kvStride, float[] acc, int accLocal, int headDim)
+    {
+        if (!Avx512F.IsSupported || (headDim & 63) != 0)
+        {
+            for (int jj = 0; jj < cnt; jj++)
+            {
+                AxpyHeads4(sbuf[0 * KeyChunk + jj], sbuf[1 * KeyChunk + jj], sbuf[2 * KeyChunk + jj], sbuf[3 * KeyChunk + jj],
+                           v, (kb + jj) * kvStride, acc, accLocal, headDim);
+            }
+            return;
+        }
+
+        ref float vr = ref v[0];
+        ref float ar = ref acc[0];
+        int h0 = accLocal, h1 = accLocal + headDim, h2 = accLocal + 2 * headDim, h3 = accLocal + 3 * headDim;
+
+        for (int nt = 0; nt < headDim; nt += 64) // 4-column-vector output tile (64 floats)
+        {
+            var a00 = Vector512.LoadUnsafe(ref ar, (nuint)(h0 + nt));      var a01 = Vector512.LoadUnsafe(ref ar, (nuint)(h0 + nt + 16));
+            var a02 = Vector512.LoadUnsafe(ref ar, (nuint)(h0 + nt + 32)); var a03 = Vector512.LoadUnsafe(ref ar, (nuint)(h0 + nt + 48));
+            var a10 = Vector512.LoadUnsafe(ref ar, (nuint)(h1 + nt));      var a11 = Vector512.LoadUnsafe(ref ar, (nuint)(h1 + nt + 16));
+            var a12 = Vector512.LoadUnsafe(ref ar, (nuint)(h1 + nt + 32)); var a13 = Vector512.LoadUnsafe(ref ar, (nuint)(h1 + nt + 48));
+            var a20 = Vector512.LoadUnsafe(ref ar, (nuint)(h2 + nt));      var a21 = Vector512.LoadUnsafe(ref ar, (nuint)(h2 + nt + 16));
+            var a22 = Vector512.LoadUnsafe(ref ar, (nuint)(h2 + nt + 32)); var a23 = Vector512.LoadUnsafe(ref ar, (nuint)(h2 + nt + 48));
+            var a30 = Vector512.LoadUnsafe(ref ar, (nuint)(h3 + nt));      var a31 = Vector512.LoadUnsafe(ref ar, (nuint)(h3 + nt + 16));
+            var a32 = Vector512.LoadUnsafe(ref ar, (nuint)(h3 + nt + 32)); var a33 = Vector512.LoadUnsafe(ref ar, (nuint)(h3 + nt + 48));
+
+            for (int jj = 0; jj < cnt; jj++)
+            {
+                int vb = (kb + jj) * kvStride + nt;
+                var v0 = Vector512.LoadUnsafe(ref vr, (nuint)vb);      var v1 = Vector512.LoadUnsafe(ref vr, (nuint)(vb + 16));
+                var v2 = Vector512.LoadUnsafe(ref vr, (nuint)(vb + 32)); var v3 = Vector512.LoadUnsafe(ref vr, (nuint)(vb + 48));
+                var b0 = Vector512.Create(sbuf[0 * KeyChunk + jj]);
+                var b1 = Vector512.Create(sbuf[1 * KeyChunk + jj]);
+                var b2 = Vector512.Create(sbuf[2 * KeyChunk + jj]);
+                var b3 = Vector512.Create(sbuf[3 * KeyChunk + jj]);
+                a00 = Avx512F.FusedMultiplyAdd(b0, v0, a00); a01 = Avx512F.FusedMultiplyAdd(b0, v1, a01); a02 = Avx512F.FusedMultiplyAdd(b0, v2, a02); a03 = Avx512F.FusedMultiplyAdd(b0, v3, a03);
+                a10 = Avx512F.FusedMultiplyAdd(b1, v0, a10); a11 = Avx512F.FusedMultiplyAdd(b1, v1, a11); a12 = Avx512F.FusedMultiplyAdd(b1, v2, a12); a13 = Avx512F.FusedMultiplyAdd(b1, v3, a13);
+                a20 = Avx512F.FusedMultiplyAdd(b2, v0, a20); a21 = Avx512F.FusedMultiplyAdd(b2, v1, a21); a22 = Avx512F.FusedMultiplyAdd(b2, v2, a22); a23 = Avx512F.FusedMultiplyAdd(b2, v3, a23);
+                a30 = Avx512F.FusedMultiplyAdd(b3, v0, a30); a31 = Avx512F.FusedMultiplyAdd(b3, v1, a31); a32 = Avx512F.FusedMultiplyAdd(b3, v2, a32); a33 = Avx512F.FusedMultiplyAdd(b3, v3, a33);
+            }
+
+            a00.StoreUnsafe(ref ar, (nuint)(h0 + nt));      a01.StoreUnsafe(ref ar, (nuint)(h0 + nt + 16));
+            a02.StoreUnsafe(ref ar, (nuint)(h0 + nt + 32)); a03.StoreUnsafe(ref ar, (nuint)(h0 + nt + 48));
+            a10.StoreUnsafe(ref ar, (nuint)(h1 + nt));      a11.StoreUnsafe(ref ar, (nuint)(h1 + nt + 16));
+            a12.StoreUnsafe(ref ar, (nuint)(h1 + nt + 32)); a13.StoreUnsafe(ref ar, (nuint)(h1 + nt + 48));
+            a20.StoreUnsafe(ref ar, (nuint)(h2 + nt));      a21.StoreUnsafe(ref ar, (nuint)(h2 + nt + 16));
+            a22.StoreUnsafe(ref ar, (nuint)(h2 + nt + 32)); a23.StoreUnsafe(ref ar, (nuint)(h2 + nt + 48));
+            a30.StoreUnsafe(ref ar, (nuint)(h3 + nt));      a31.StoreUnsafe(ref ar, (nuint)(h3 + nt + 16));
+            a32.StoreUnsafe(ref ar, (nuint)(h3 + nt + 32)); a33.StoreUnsafe(ref ar, (nuint)(h3 + nt + 48));
         }
     }
 

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -297,14 +297,14 @@ internal sealed class Gemma3Model
     /// × all query heads, so each cache line of K/V services <c>QueryBlock * NumHeads</c> dot products
     /// instead of one. Keeps the per-block score scratch (<c>QueryBlock * heads * seq</c> floats) and the
     /// queries it sweeps comfortably cache-resident.</summary>
-    private const int QueryBlock = 8;
+    private const int QueryBlock = 16;
 
     /// <summary>Causal grouped-query attention. The single KV head is shared by all query heads.
     /// Parallelizes over <see cref="QueryBlock"/>-sized blocks of query positions via
-    /// <see cref="ParallelExecution.ForAsync"/> (dynamic load balancing for the triangular causal work
-    /// when the caller requests parallelism, single-threaded otherwise). The math is identical to a
-    /// per-(query, head) loop - the keys/values are merely streamed in an order that reuses each K/V
-    /// vector across the whole block, which is the dominant cost of the quadratic attention term.</summary>
+    /// <see cref="ParallelExecution.ForAsync"/> (dynamic load balancing for the triangular causal work).
+    /// On x64 each block runs the fused flash-attention kernel (<see cref="FlashAttentionBlock"/>) - a
+    /// single streaming pass over the keys with an online softmax that never materializes the
+    /// seq×seq score matrix; other hosts use the portable head-fused path.</summary>
     private Task AttentionAsync(float[] q, float[] k, float[] v, float[] attnOut, int seq, int headDim, ParallelOptions parallelOptions)
     {
         int qStride  = _cfg.NumHeads * headDim;
@@ -312,41 +312,33 @@ internal sealed class Gemma3Model
         int heads    = _cfg.NumHeads;
         float scale  = _cfg.AttentionScale;
 
-        // The fused score/value kernels are specialized for this model's 4 query heads.
-        if (heads != 4)
-        {
-            throw new NotSupportedException($"Fused attention expects 4 query heads, got {heads}.");
-        }
-
+        bool useFlash = !ForwardProfile.ForcePortableAttention && Fma.IsSupported && (headDim & 7) == 0;
         int numBlocks = (seq + QueryBlock - 1) / QueryBlock;
 
         return ParallelExecution.ForAsync(0, numBlocks, parallelOptions, (b, _) =>
         {
             int q0 = b * QueryBlock;
             int q1 = Math.Min(q0 + QueryBlock, seq);
-            AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+            if (useFlash)
+            {
+                FlashAttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+            }
+            else
+            {
+                AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+            }
             return ValueTask.CompletedTask;
         });
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    /// <summary>Computes attention output for the query positions <c>[q0, q1)</c> across all 4 heads.
-    /// Key/value vectors are loaded in the outer loop so each is reused across every query in the block,
-    /// and the four GQA query heads are fused into a single SIMD pass per key/value (see
-    /// <see cref="ScoreHeads4"/>/<see cref="AxpyHeads4"/>), keeping K/V cache-resident during reuse and
-    /// cutting the dot/axpy call count ~4x. The per-(query, head) softmax and the j-ordered value
-    /// accumulation are preserved; only the in-dot lane reassociation differs from a scalar dot, so the
-    /// output matches the reference to float tolerance.</summary>
+    /// <summary>Portable (no-intrinsics-required) attention for the query positions <c>[q0, q1)</c>:
+    /// materializes per-query causal scores, softmaxes them, then accumulates the value sum. Keys/values
+    /// are streamed key-outer so each is reused across the block, and the four GQA query heads are fused
+    /// into one SIMD pass per key/value via <see cref="ScoreHeads4"/>/<see cref="AxpyHeads4"/>. Used as
+    /// the fallback when the x64 flash kernel is unavailable.</summary>
     private static void AttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
-        // Fast path: register-tiled FMA GEMM kernels for a full 8-query block on x64 (see
-        // AttentionBlockFma). Partial last block / non-FMA hosts use the portable head-fused path.
-        if (!ForwardProfile.ForcePortableAttention && Fma.IsSupported && (q1 - q0) == QueryBlock && (headDim & 7) == 0)
-        {
-            AttentionBlockFma(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, scale);
-            return;
-        }
-
         int blk     = q1 - q0;
         int nKeys   = q1;                 // keys 0..q1-1 are the most any query in this block attends to
         int perQ    = heads * nKeys;      // scores stride per query in the block
@@ -416,136 +408,122 @@ internal sealed class Gemma3Model
     }
 
     /// <summary>
-    /// Register-tiled FMA implementation of <see cref="AttentionBlock"/> for a full <see cref="QueryBlock"/>
-    /// (8-query) block on x64. The two attention matmuls are computed as small GEMM microkernels instead
-    /// of per-(query, head) dot products:
-    /// <list type="bullet">
-    /// <item><b>scores</b> Q·Kᵀ as 4-query × 2-key register tiles (8 FMA accumulators), so each loaded
-    /// query/key SIMD vector feeds multiple outputs;</item>
-    /// <item><b>value</b> S·V with the 4 query output rows of a sub-tile accumulated in place while each
-    /// V row is loaded once and reused across them.</item>
-    /// </list>
-    /// Scores are computed densely over the block's key range and the per-query causal tail is zeroed
-    /// after softmax, so the value matmul needs no inner causal branch. Float results match the reference
-    /// to tolerance (SIMD/FMA reassociation only).
+    /// Flash-attention kernel for the query positions <c>[q0, q1)</c> across all heads, used on x64.
+    /// Streams the keys/values exactly once per block while maintaining, per (query, head), an
+    /// online-softmax running max, denominator and value accumulator - so the seq×seq score matrix is
+    /// never materialized (the old path wrote it then re-read it twice) and K/V are read far fewer times.
+    /// Each dot/axpy uses 256-bit FMA. Float results match the reference to tolerance (online-softmax and
+    /// FMA reassociation only).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private static void AttentionBlockFma(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, float scale)
+    private static void FlashAttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
-        const int HEADS = 4;
-        int blk   = q1 - q0;          // == QueryBlock (8)
-        int nKeys = q1;
-        int perQ  = HEADS * nKeys;
-        float[] scores = ArrayPool<float>.Shared.Rent(blk * perQ);
+        int blk    = q1 - q0;
+        int nState = blk * heads;
+        float[] acc   = ArrayPool<float>.Shared.Rent(nState * headDim);
+        float[] mlBuf = ArrayPool<float>.Shared.Rent(nState * 2);
+        Array.Clear(acc, 0, nState * headDim);
+        Span<float> m = mlBuf.AsSpan(0, nState);
+        Span<float> l = mlBuf.AsSpan(nState, nState);
+        m.Fill(float.NegativeInfinity);
+        l.Clear();
 
         ref float qr = ref q[0];
         ref float kr = ref k[0];
         ref float vr = ref v[0];
-        ref float outr = ref attnOut[0];
 
-        // ---- scores: dense Q[block] · K[0..nKeys)^T per head, tiled 4 queries × 2 keys ----
-        for (int head = 0; head < HEADS; head++)
+        for (int head = 0; head < heads; head++)
         {
             int headOff = head * headDim;
-            for (int qt = 0; qt < blk; qt += 4)
+            for (int j = 0; j < q1; j++)
             {
-                int qb0 = (q0 + qt) * qStride + headOff;
-                int qb1 = qb0 + qStride, qb2 = qb1 + qStride, qb3 = qb2 + qStride;
-                int sb0 = (qt + 0) * perQ + head * nKeys;
-                int sb1 = sb0 + perQ, sb2 = sb1 + perQ, sb3 = sb2 + perQ;
+                int kb = j * kvStride;
+                int localStart = j > q0 ? j - q0 : 0; // only queries qi = q0+local >= j attend to key j
+                for (int local = localStart; local < blk; local++)
+                {
+                    int qb = (q0 + local) * qStride + headOff;
+                    float s = DotFma(ref qr, qb, ref kr, kb, headDim) * scale;
 
-                int j = 0;
-                for (; j + 2 <= nKeys; j += 2)
-                {
-                    int kb0 = j * kvStride, kb1 = kb0 + kvStride;
-                    Vector256<float> c00 = default, c01 = default, c10 = default, c11 = default,
-                                     c20 = default, c21 = default, c30 = default, c31 = default;
-                    for (int d = 0; d < headDim; d += 8)
+                    int st = local * heads + head;
+                    int accBase = st * headDim;
+                    float mPrev = m[st];
+                    if (s <= mPrev)
                     {
-                        var k0 = Vector256.LoadUnsafe(ref kr, (nuint)(kb0 + d));
-                        var k1 = Vector256.LoadUnsafe(ref kr, (nuint)(kb1 + d));
-                        var a0 = Vector256.LoadUnsafe(ref qr, (nuint)(qb0 + d)); c00 = Fma.MultiplyAdd(a0, k0, c00); c01 = Fma.MultiplyAdd(a0, k1, c01);
-                        var a1 = Vector256.LoadUnsafe(ref qr, (nuint)(qb1 + d)); c10 = Fma.MultiplyAdd(a1, k0, c10); c11 = Fma.MultiplyAdd(a1, k1, c11);
-                        var a2 = Vector256.LoadUnsafe(ref qr, (nuint)(qb2 + d)); c20 = Fma.MultiplyAdd(a2, k0, c20); c21 = Fma.MultiplyAdd(a2, k1, c21);
-                        var a3 = Vector256.LoadUnsafe(ref qr, (nuint)(qb3 + d)); c30 = Fma.MultiplyAdd(a3, k0, c30); c31 = Fma.MultiplyAdd(a3, k1, c31);
+                        float p = MathF.Exp(s - mPrev);
+                        l[st] += p;
+                        AxpyFma(acc, accBase, ref vr, kb, p, headDim);          // acc += p * v_j
                     }
-                    scores[sb0 + j] = Vector256.Sum(c00) * scale; scores[sb0 + j + 1] = Vector256.Sum(c01) * scale;
-                    scores[sb1 + j] = Vector256.Sum(c10) * scale; scores[sb1 + j + 1] = Vector256.Sum(c11) * scale;
-                    scores[sb2 + j] = Vector256.Sum(c20) * scale; scores[sb2 + j + 1] = Vector256.Sum(c21) * scale;
-                    scores[sb3 + j] = Vector256.Sum(c30) * scale; scores[sb3 + j + 1] = Vector256.Sum(c31) * scale;
-                }
-                for (; j < nKeys; j++) // odd-key tail
-                {
-                    int kb0 = j * kvStride;
-                    Vector256<float> c0 = default, c1 = default, c2 = default, c3 = default;
-                    for (int d = 0; d < headDim; d += 8)
+                    else
                     {
-                        var k0 = Vector256.LoadUnsafe(ref kr, (nuint)(kb0 + d));
-                        c0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb0 + d)), k0, c0);
-                        c1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb1 + d)), k0, c1);
-                        c2 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb2 + d)), k0, c2);
-                        c3 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb3 + d)), k0, c3);
+                        float corr = float.IsNegativeInfinity(mPrev) ? 0f : MathF.Exp(mPrev - s);
+                        ScaleAxpyFma(acc, accBase, corr, ref vr, kb, headDim);  // acc = acc*corr + v_j (p == 1)
+                        l[st] = l[st] * corr + 1f;
+                        m[st] = s;
                     }
-                    scores[sb0 + j] = Vector256.Sum(c0) * scale;
-                    scores[sb1 + j] = Vector256.Sum(c1) * scale;
-                    scores[sb2 + j] = Vector256.Sum(c2) * scale;
-                    scores[sb3 + j] = Vector256.Sum(c3) * scale;
                 }
+            }
+
+            for (int local = 0; local < blk; local++)
+            {
+                int st = local * heads + head;
+                float inv = l[st] > 0f ? 1f / l[st] : 0f;
+                ScaleTo(acc, st * headDim, attnOut, (q0 + local) * qStride + headOff, inv, headDim);
             }
         }
 
-        // ---- per-(query, head) softmax over the causal prefix, then zero the stale tail (j > qi) so the
-        //      value matmul can run over the whole block key range without a per-element causal branch ----
-        for (int local = 0; local < blk; local++)
+        ArrayPool<float>.Shared.Return(acc);
+        ArrayPool<float>.Shared.Return(mlBuf);
+    }
+
+    /// <summary>256-bit FMA dot product over <paramref name="dim"/> (a multiple of 8).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float DotFma(ref float a, int aOff, ref float b, int bOff, int dim)
+    {
+        var acc = Vector256<float>.Zero;
+        for (int d = 0; d < dim; d += 8)
         {
-            int qi = q0 + local;
-            int sBase = local * perQ;
-            for (int head = 0; head < HEADS; head++)
-            {
-                int b = sBase + head * nKeys;
-                Ops.SoftmaxInPlace(scores.AsSpan(b, qi + 1), qi + 1);
-                Array.Clear(scores, b + qi + 1, nKeys - qi - 1);
-            }
+            acc = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref a, (nuint)(aOff + d)), Vector256.LoadUnsafe(ref b, (nuint)(bOff + d)), acc);
         }
+        return Vector256.Sum(acc);
+    }
 
-        // ---- value: out += scores · V per head, 4 query rows of a sub-tile accumulated together while
-        //      each V row is loaded once. Only keys up to the sub-tile's last query matter (rest zeroed). ----
-        for (int head = 0; head < HEADS; head++)
+    /// <summary><c>acc += p * v</c> over <paramref name="dim"/> (FMA).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AxpyFma(float[] acc, int accBase, ref float v, int vOff, float p, int dim)
+    {
+        ref float ar = ref acc[0];
+        var pv = Vector256.Create(p);
+        for (int d = 0; d < dim; d += 8)
         {
-            int headOff = head * headDim;
-            for (int qt = 0; qt < blk; qt += 4)
-            {
-                int ob0 = (q0 + qt) * qStride + headOff;
-                int ob1 = ob0 + qStride, ob2 = ob1 + qStride, ob3 = ob2 + qStride;
-                Array.Clear(attnOut, ob0, headDim);
-                Array.Clear(attnOut, ob1, headDim);
-                Array.Clear(attnOut, ob2, headDim);
-                Array.Clear(attnOut, ob3, headDim);
-
-                int sb0 = (qt + 0) * perQ + head * nKeys;
-                int sb1 = sb0 + perQ, sb2 = sb1 + perQ, sb3 = sb2 + perQ;
-                int jMax = Math.Min(nKeys, q0 + qt + 4); // keys beyond the sub-tile's last query are all zero
-
-                for (int j = 0; j < jMax; j++)
-                {
-                    int vb = j * kvStride;
-                    var w0 = Vector256.Create(scores[sb0 + j]);
-                    var w1 = Vector256.Create(scores[sb1 + j]);
-                    var w2 = Vector256.Create(scores[sb2 + j]);
-                    var w3 = Vector256.Create(scores[sb3 + j]);
-                    for (int d = 0; d < headDim; d += 8)
-                    {
-                        var vv = Vector256.LoadUnsafe(ref vr, (nuint)(vb + d));
-                        Fma.MultiplyAdd(w0, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob0 + d))).StoreUnsafe(ref outr, (nuint)(ob0 + d));
-                        Fma.MultiplyAdd(w1, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob1 + d))).StoreUnsafe(ref outr, (nuint)(ob1 + d));
-                        Fma.MultiplyAdd(w2, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob2 + d))).StoreUnsafe(ref outr, (nuint)(ob2 + d));
-                        Fma.MultiplyAdd(w3, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob3 + d))).StoreUnsafe(ref outr, (nuint)(ob3 + d));
-                    }
-                }
-            }
+            Fma.MultiplyAdd(pv, Vector256.LoadUnsafe(ref v, (nuint)(vOff + d)), Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)))
+               .StoreUnsafe(ref ar, (nuint)(accBase + d));
         }
+    }
 
-        ArrayPool<float>.Shared.Return(scores);
+    /// <summary><c>acc = acc * corr + v</c> over <paramref name="dim"/> (FMA, online-softmax rescale).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ScaleAxpyFma(float[] acc, int accBase, float corr, ref float v, int vOff, int dim)
+    {
+        ref float ar = ref acc[0];
+        var cv = Vector256.Create(corr);
+        for (int d = 0; d < dim; d += 8)
+        {
+            Fma.MultiplyAdd(Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)), cv, Vector256.LoadUnsafe(ref v, (nuint)(vOff + d)))
+               .StoreUnsafe(ref ar, (nuint)(accBase + d));
+        }
+    }
+
+    /// <summary><c>out = acc * inv</c> over <paramref name="dim"/> (final softmax normalization).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ScaleTo(float[] acc, int accBase, float[] outArr, int outBase, float inv, int dim)
+    {
+        ref float ar = ref acc[0];
+        ref float orf = ref outArr[0];
+        var iv = Vector256.Create(inv);
+        for (int d = 0; d < dim; d += 8)
+        {
+            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * iv).StoreUnsafe(ref orf, (nuint)(outBase + d));
+        }
     }
 
     /// <summary>Dots the four GQA query heads at <paramref name="qBase"/> against the single shared key

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -2,6 +2,8 @@ using System.Buffers;
 using System.Numerics;
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using SentenceTransformers;
 using SentenceTransformers.Harrier.Small.Pure.Numerics;
 
@@ -337,6 +339,14 @@ internal sealed class Gemma3Model
     /// output matches the reference to float tolerance.</summary>
     private static void AttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
+        // Fast path: register-tiled FMA GEMM kernels for a full 8-query block on x64 (see
+        // AttentionBlockFma). Partial last block / non-FMA hosts use the portable head-fused path.
+        if (!ForwardProfile.ForcePortableAttention && Fma.IsSupported && (q1 - q0) == QueryBlock && (headDim & 7) == 0)
+        {
+            AttentionBlockFma(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, scale);
+            return;
+        }
+
         int blk     = q1 - q0;
         int nKeys   = q1;                 // keys 0..q1-1 are the most any query in this block attends to
         int perQ    = heads * nKeys;      // scores stride per query in the block
@@ -399,6 +409,139 @@ internal sealed class Gemma3Model
                     scores[sBase + 2 * nKeys + j],
                     scores[sBase + 3 * nKeys + j],
                     v, vBase, attnOut, qBase, headDim);
+            }
+        }
+
+        ArrayPool<float>.Shared.Return(scores);
+    }
+
+    /// <summary>
+    /// Register-tiled FMA implementation of <see cref="AttentionBlock"/> for a full <see cref="QueryBlock"/>
+    /// (8-query) block on x64. The two attention matmuls are computed as small GEMM microkernels instead
+    /// of per-(query, head) dot products:
+    /// <list type="bullet">
+    /// <item><b>scores</b> Q·Kᵀ as 4-query × 2-key register tiles (8 FMA accumulators), so each loaded
+    /// query/key SIMD vector feeds multiple outputs;</item>
+    /// <item><b>value</b> S·V with the 4 query output rows of a sub-tile accumulated in place while each
+    /// V row is loaded once and reused across them.</item>
+    /// </list>
+    /// Scores are computed densely over the block's key range and the per-query causal tail is zeroed
+    /// after softmax, so the value matmul needs no inner causal branch. Float results match the reference
+    /// to tolerance (SIMD/FMA reassociation only).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void AttentionBlockFma(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, float scale)
+    {
+        const int HEADS = 4;
+        int blk   = q1 - q0;          // == QueryBlock (8)
+        int nKeys = q1;
+        int perQ  = HEADS * nKeys;
+        float[] scores = ArrayPool<float>.Shared.Rent(blk * perQ);
+
+        ref float qr = ref q[0];
+        ref float kr = ref k[0];
+        ref float vr = ref v[0];
+        ref float outr = ref attnOut[0];
+
+        // ---- scores: dense Q[block] · K[0..nKeys)^T per head, tiled 4 queries × 2 keys ----
+        for (int head = 0; head < HEADS; head++)
+        {
+            int headOff = head * headDim;
+            for (int qt = 0; qt < blk; qt += 4)
+            {
+                int qb0 = (q0 + qt) * qStride + headOff;
+                int qb1 = qb0 + qStride, qb2 = qb1 + qStride, qb3 = qb2 + qStride;
+                int sb0 = (qt + 0) * perQ + head * nKeys;
+                int sb1 = sb0 + perQ, sb2 = sb1 + perQ, sb3 = sb2 + perQ;
+
+                int j = 0;
+                for (; j + 2 <= nKeys; j += 2)
+                {
+                    int kb0 = j * kvStride, kb1 = kb0 + kvStride;
+                    Vector256<float> c00 = default, c01 = default, c10 = default, c11 = default,
+                                     c20 = default, c21 = default, c30 = default, c31 = default;
+                    for (int d = 0; d < headDim; d += 8)
+                    {
+                        var k0 = Vector256.LoadUnsafe(ref kr, (nuint)(kb0 + d));
+                        var k1 = Vector256.LoadUnsafe(ref kr, (nuint)(kb1 + d));
+                        var a0 = Vector256.LoadUnsafe(ref qr, (nuint)(qb0 + d)); c00 = Fma.MultiplyAdd(a0, k0, c00); c01 = Fma.MultiplyAdd(a0, k1, c01);
+                        var a1 = Vector256.LoadUnsafe(ref qr, (nuint)(qb1 + d)); c10 = Fma.MultiplyAdd(a1, k0, c10); c11 = Fma.MultiplyAdd(a1, k1, c11);
+                        var a2 = Vector256.LoadUnsafe(ref qr, (nuint)(qb2 + d)); c20 = Fma.MultiplyAdd(a2, k0, c20); c21 = Fma.MultiplyAdd(a2, k1, c21);
+                        var a3 = Vector256.LoadUnsafe(ref qr, (nuint)(qb3 + d)); c30 = Fma.MultiplyAdd(a3, k0, c30); c31 = Fma.MultiplyAdd(a3, k1, c31);
+                    }
+                    scores[sb0 + j] = Vector256.Sum(c00) * scale; scores[sb0 + j + 1] = Vector256.Sum(c01) * scale;
+                    scores[sb1 + j] = Vector256.Sum(c10) * scale; scores[sb1 + j + 1] = Vector256.Sum(c11) * scale;
+                    scores[sb2 + j] = Vector256.Sum(c20) * scale; scores[sb2 + j + 1] = Vector256.Sum(c21) * scale;
+                    scores[sb3 + j] = Vector256.Sum(c30) * scale; scores[sb3 + j + 1] = Vector256.Sum(c31) * scale;
+                }
+                for (; j < nKeys; j++) // odd-key tail
+                {
+                    int kb0 = j * kvStride;
+                    Vector256<float> c0 = default, c1 = default, c2 = default, c3 = default;
+                    for (int d = 0; d < headDim; d += 8)
+                    {
+                        var k0 = Vector256.LoadUnsafe(ref kr, (nuint)(kb0 + d));
+                        c0 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb0 + d)), k0, c0);
+                        c1 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb1 + d)), k0, c1);
+                        c2 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb2 + d)), k0, c2);
+                        c3 = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref qr, (nuint)(qb3 + d)), k0, c3);
+                    }
+                    scores[sb0 + j] = Vector256.Sum(c0) * scale;
+                    scores[sb1 + j] = Vector256.Sum(c1) * scale;
+                    scores[sb2 + j] = Vector256.Sum(c2) * scale;
+                    scores[sb3 + j] = Vector256.Sum(c3) * scale;
+                }
+            }
+        }
+
+        // ---- per-(query, head) softmax over the causal prefix, then zero the stale tail (j > qi) so the
+        //      value matmul can run over the whole block key range without a per-element causal branch ----
+        for (int local = 0; local < blk; local++)
+        {
+            int qi = q0 + local;
+            int sBase = local * perQ;
+            for (int head = 0; head < HEADS; head++)
+            {
+                int b = sBase + head * nKeys;
+                Ops.SoftmaxInPlace(scores.AsSpan(b, qi + 1), qi + 1);
+                Array.Clear(scores, b + qi + 1, nKeys - qi - 1);
+            }
+        }
+
+        // ---- value: out += scores · V per head, 4 query rows of a sub-tile accumulated together while
+        //      each V row is loaded once. Only keys up to the sub-tile's last query matter (rest zeroed). ----
+        for (int head = 0; head < HEADS; head++)
+        {
+            int headOff = head * headDim;
+            for (int qt = 0; qt < blk; qt += 4)
+            {
+                int ob0 = (q0 + qt) * qStride + headOff;
+                int ob1 = ob0 + qStride, ob2 = ob1 + qStride, ob3 = ob2 + qStride;
+                Array.Clear(attnOut, ob0, headDim);
+                Array.Clear(attnOut, ob1, headDim);
+                Array.Clear(attnOut, ob2, headDim);
+                Array.Clear(attnOut, ob3, headDim);
+
+                int sb0 = (qt + 0) * perQ + head * nKeys;
+                int sb1 = sb0 + perQ, sb2 = sb1 + perQ, sb3 = sb2 + perQ;
+                int jMax = Math.Min(nKeys, q0 + qt + 4); // keys beyond the sub-tile's last query are all zero
+
+                for (int j = 0; j < jMax; j++)
+                {
+                    int vb = j * kvStride;
+                    var w0 = Vector256.Create(scores[sb0 + j]);
+                    var w1 = Vector256.Create(scores[sb1 + j]);
+                    var w2 = Vector256.Create(scores[sb2 + j]);
+                    var w3 = Vector256.Create(scores[sb3 + j]);
+                    for (int d = 0; d < headDim; d += 8)
+                    {
+                        var vv = Vector256.LoadUnsafe(ref vr, (nuint)(vb + d));
+                        Fma.MultiplyAdd(w0, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob0 + d))).StoreUnsafe(ref outr, (nuint)(ob0 + d));
+                        Fma.MultiplyAdd(w1, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob1 + d))).StoreUnsafe(ref outr, (nuint)(ob1 + d));
+                        Fma.MultiplyAdd(w2, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob2 + d))).StoreUnsafe(ref outr, (nuint)(ob2 + d));
+                        Fma.MultiplyAdd(w3, vv, Vector256.LoadUnsafe(ref outr, (nuint)(ob3 + d))).StoreUnsafe(ref outr, (nuint)(ob3 + d));
+                    }
+                }
             }
         }
 

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -167,34 +167,63 @@ internal sealed class Gemma3Model
             {
                 parallelOptions.CancellationToken.ThrowIfCancellationRequested();
 
+                long ts;
                 // ---- self attention ----
+                ts = ForwardProfile.Start();
                 Ops.RmsNorm(hidden, layer.InputLayerNorm, normed, seq, h, _cfg.RmsNormEps);
+                ForwardProfile.Stop("norm+resid", ts);
+
+                ts = ForwardProfile.Start();
                 await layer.QProj.MultiplyAsync(normed, q, seq, parallelOptions).ConfigureAwait(false);
                 await layer.KProj.MultiplyAsync(normed, k, seq, parallelOptions).ConfigureAwait(false);
                 await layer.VProj.MultiplyAsync(normed, v, seq, parallelOptions).ConfigureAwait(false);
+                ForwardProfile.Stop("qkv_proj", ts);
 
+                ts = ForwardProfile.Start();
                 ApplyHeadNorm(q, layer.QNorm, seq, _cfg.NumHeads, headDim);
                 ApplyHeadNorm(k, layer.KNorm, seq, _cfg.NumKvHeads, headDim);
 
                 ApplyRope(q, cos, sin, seq, _cfg.NumHeads, headDim);
                 ApplyRope(k, cos, sin, seq, _cfg.NumKvHeads, headDim);
+                ForwardProfile.Stop("headnorm+rope", ts);
 
+                ts = ForwardProfile.Start();
                 await AttentionAsync(q, k, v, attnOut, seq, headDim, parallelOptions).ConfigureAwait(false);
+                ForwardProfile.Stop("attention", ts);
 
+                ts = ForwardProfile.Start();
                 await layer.OProj.MultiplyAsync(attnOut, attnProj, seq, parallelOptions).ConfigureAwait(false);
+                ForwardProfile.Stop("o_proj", ts);
+
                 // post-attention norm then residual add
+                ts = ForwardProfile.Start();
                 Ops.RmsNorm(attnProj, layer.PostAttentionLayerNorm, attnProj, seq, h, _cfg.RmsNormEps);
                 TensorPrimitives.Add(hidden.AsSpan(0, hiddenLen), attnProj.AsSpan(0, hiddenLen), hidden.AsSpan(0, hiddenLen));
+                ForwardProfile.Stop("norm+resid", ts);
 
                 // ---- feed forward ----
+                ts = ForwardProfile.Start();
                 Ops.RmsNorm(hidden, layer.PreFeedforwardLayerNorm, normed, seq, h, _cfg.RmsNormEps);
+                ForwardProfile.Stop("norm+resid", ts);
+
+                ts = ForwardProfile.Start();
                 await layer.GateProj.MultiplyAsync(normed, gate, seq, parallelOptions).ConfigureAwait(false);
                 await layer.UpProj.MultiplyAsync(normed, up, seq, parallelOptions).ConfigureAwait(false);
+                ForwardProfile.Stop("mlp_proj", ts);
+
                 int ffLen = seq * _cfg.IntermediateSize;
+                ts = ForwardProfile.Start();
                 Ops.GeGluInPlace(gate.AsSpan(0, ffLen), up.AsSpan(0, ffLen));
+                ForwardProfile.Stop("geglu", ts);
+
+                ts = ForwardProfile.Start();
                 await layer.DownProj.MultiplyAsync(gate, down, seq, parallelOptions).ConfigureAwait(false);
+                ForwardProfile.Stop("mlp_proj", ts);
+
+                ts = ForwardProfile.Start();
                 Ops.RmsNorm(down, layer.PostFeedforwardLayerNorm, down, seq, h, _cfg.RmsNormEps);
                 TensorPrimitives.Add(hidden.AsSpan(0, hiddenLen), down.AsSpan(0, hiddenLen), hidden.AsSpan(0, hiddenLen));
+                ForwardProfile.Stop("norm+resid", ts);
             }
 
             // ---- final norm + last-token pooling ----

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -302,9 +302,11 @@ internal sealed class Gemma3Model
     /// <summary>Causal grouped-query attention. The single KV head is shared by all query heads.
     /// Parallelizes over <see cref="QueryBlock"/>-sized blocks of query positions via
     /// <see cref="ParallelExecution.ForAsync"/> (dynamic load balancing for the triangular causal work).
-    /// On x64 each block runs the fused flash-attention kernel (<see cref="FlashAttentionBlock"/>) - a
-    /// single streaming pass over the keys with an online softmax that never materializes the
-    /// seq×seq score matrix; other hosts use the portable head-fused path.</summary>
+    /// Each block computes scores tile-by-tile, applies a vectorized softmax, then the value sum, reusing
+    /// each key/value vector across the whole block (the dominant cost of the quadratic attention term).
+    /// A streaming online-softmax (flash) variant was measured slower here: on CPU the per-element scalar
+    /// <c>exp</c> it requires loses badly to the materialized path's vectorized <c>TensorPrimitives.Exp</c>
+    /// over whole score rows.</summary>
     private Task AttentionAsync(float[] q, float[] k, float[] v, float[] attnOut, int seq, int headDim, ParallelOptions parallelOptions)
     {
         int qStride  = _cfg.NumHeads * headDim;
@@ -312,21 +314,13 @@ internal sealed class Gemma3Model
         int heads    = _cfg.NumHeads;
         float scale  = _cfg.AttentionScale;
 
-        bool useFlash = !ForwardProfile.ForcePortableAttention && Fma.IsSupported && (headDim & 7) == 0;
         int numBlocks = (seq + QueryBlock - 1) / QueryBlock;
 
         return ParallelExecution.ForAsync(0, numBlocks, parallelOptions, (b, _) =>
         {
             int q0 = b * QueryBlock;
             int q1 = Math.Min(q0 + QueryBlock, seq);
-            if (useFlash)
-            {
-                FlashAttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
-            }
-            else
-            {
-                AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
-            }
+            AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
             return ValueTask.CompletedTask;
         });
     }
@@ -405,125 +399,6 @@ internal sealed class Gemma3Model
         }
 
         ArrayPool<float>.Shared.Return(scores);
-    }
-
-    /// <summary>
-    /// Flash-attention kernel for the query positions <c>[q0, q1)</c> across all heads, used on x64.
-    /// Streams the keys/values exactly once per block while maintaining, per (query, head), an
-    /// online-softmax running max, denominator and value accumulator - so the seq×seq score matrix is
-    /// never materialized (the old path wrote it then re-read it twice) and K/V are read far fewer times.
-    /// Each dot/axpy uses 256-bit FMA. Float results match the reference to tolerance (online-softmax and
-    /// FMA reassociation only).
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private static void FlashAttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
-    {
-        int blk    = q1 - q0;
-        int nState = blk * heads;
-        float[] acc   = ArrayPool<float>.Shared.Rent(nState * headDim);
-        float[] mlBuf = ArrayPool<float>.Shared.Rent(nState * 2);
-        Array.Clear(acc, 0, nState * headDim);
-        Span<float> m = mlBuf.AsSpan(0, nState);
-        Span<float> l = mlBuf.AsSpan(nState, nState);
-        m.Fill(float.NegativeInfinity);
-        l.Clear();
-
-        ref float qr = ref q[0];
-        ref float kr = ref k[0];
-        ref float vr = ref v[0];
-
-        for (int head = 0; head < heads; head++)
-        {
-            int headOff = head * headDim;
-            for (int j = 0; j < q1; j++)
-            {
-                int kb = j * kvStride;
-                int localStart = j > q0 ? j - q0 : 0; // only queries qi = q0+local >= j attend to key j
-                for (int local = localStart; local < blk; local++)
-                {
-                    int qb = (q0 + local) * qStride + headOff;
-                    float s = DotFma(ref qr, qb, ref kr, kb, headDim) * scale;
-
-                    int st = local * heads + head;
-                    int accBase = st * headDim;
-                    float mPrev = m[st];
-                    if (s <= mPrev)
-                    {
-                        float p = MathF.Exp(s - mPrev);
-                        l[st] += p;
-                        AxpyFma(acc, accBase, ref vr, kb, p, headDim);          // acc += p * v_j
-                    }
-                    else
-                    {
-                        float corr = float.IsNegativeInfinity(mPrev) ? 0f : MathF.Exp(mPrev - s);
-                        ScaleAxpyFma(acc, accBase, corr, ref vr, kb, headDim);  // acc = acc*corr + v_j (p == 1)
-                        l[st] = l[st] * corr + 1f;
-                        m[st] = s;
-                    }
-                }
-            }
-
-            for (int local = 0; local < blk; local++)
-            {
-                int st = local * heads + head;
-                float inv = l[st] > 0f ? 1f / l[st] : 0f;
-                ScaleTo(acc, st * headDim, attnOut, (q0 + local) * qStride + headOff, inv, headDim);
-            }
-        }
-
-        ArrayPool<float>.Shared.Return(acc);
-        ArrayPool<float>.Shared.Return(mlBuf);
-    }
-
-    /// <summary>256-bit FMA dot product over <paramref name="dim"/> (a multiple of 8).</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static float DotFma(ref float a, int aOff, ref float b, int bOff, int dim)
-    {
-        var acc = Vector256<float>.Zero;
-        for (int d = 0; d < dim; d += 8)
-        {
-            acc = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref a, (nuint)(aOff + d)), Vector256.LoadUnsafe(ref b, (nuint)(bOff + d)), acc);
-        }
-        return Vector256.Sum(acc);
-    }
-
-    /// <summary><c>acc += p * v</c> over <paramref name="dim"/> (FMA).</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void AxpyFma(float[] acc, int accBase, ref float v, int vOff, float p, int dim)
-    {
-        ref float ar = ref acc[0];
-        var pv = Vector256.Create(p);
-        for (int d = 0; d < dim; d += 8)
-        {
-            Fma.MultiplyAdd(pv, Vector256.LoadUnsafe(ref v, (nuint)(vOff + d)), Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)))
-               .StoreUnsafe(ref ar, (nuint)(accBase + d));
-        }
-    }
-
-    /// <summary><c>acc = acc * corr + v</c> over <paramref name="dim"/> (FMA, online-softmax rescale).</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ScaleAxpyFma(float[] acc, int accBase, float corr, ref float v, int vOff, int dim)
-    {
-        ref float ar = ref acc[0];
-        var cv = Vector256.Create(corr);
-        for (int d = 0; d < dim; d += 8)
-        {
-            Fma.MultiplyAdd(Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)), cv, Vector256.LoadUnsafe(ref v, (nuint)(vOff + d)))
-               .StoreUnsafe(ref ar, (nuint)(accBase + d));
-        }
-    }
-
-    /// <summary><c>out = acc * inv</c> over <paramref name="dim"/> (final softmax normalization).</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ScaleTo(float[] acc, int accBase, float[] outArr, int outBase, float inv, int dim)
-    {
-        ref float ar = ref acc[0];
-        ref float orf = ref outArr[0];
-        var iv = Vector256.Create(inv);
-        for (int d = 0; d < dim; d += 8)
-        {
-            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * iv).StoreUnsafe(ref orf, (nuint)(outBase + d));
-        }
     }
 
     /// <summary>Dots the four GQA query heads at <paramref name="qBase"/> against the single shared key

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -598,10 +598,19 @@ internal sealed class Gemma3Model
     private static void ScaleInPlaceFma(float[] acc, int accBase, float corr, int dim)
     {
         ref float ar = ref acc[0];
-        var cv = Vector256.Create(corr);
-        for (int d = 0; d < dim; d += 8)
+        int d = 0;
+        if (Avx512F.IsSupported)
         {
-            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * cv).StoreUnsafe(ref ar, (nuint)(accBase + d));
+            var cv = Vector512.Create(corr);
+            for (; d + 16 <= dim; d += 16)
+            {
+                (Vector512.LoadUnsafe(ref ar, (nuint)(accBase + d)) * cv).StoreUnsafe(ref ar, (nuint)(accBase + d));
+            }
+        }
+        var cv2 = Vector256.Create(corr);
+        for (; d < dim; d += 8)
+        {
+            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * cv2).StoreUnsafe(ref ar, (nuint)(accBase + d));
         }
     }
 
@@ -611,10 +620,19 @@ internal sealed class Gemma3Model
     {
         ref float ar = ref acc[0];
         ref float orf = ref outArr[0];
-        var iv = Vector256.Create(inv);
-        for (int d = 0; d < dim; d += 8)
+        int d = 0;
+        if (Avx512F.IsSupported)
         {
-            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * iv).StoreUnsafe(ref orf, (nuint)(outBase + d));
+            var iv = Vector512.Create(inv);
+            for (; d + 16 <= dim; d += 16)
+            {
+                (Vector512.LoadUnsafe(ref ar, (nuint)(accBase + d)) * iv).StoreUnsafe(ref orf, (nuint)(outBase + d));
+            }
+        }
+        var iv2 = Vector256.Create(inv);
+        for (; d < dim; d += 8)
+        {
+            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * iv2).StoreUnsafe(ref orf, (nuint)(outBase + d));
         }
     }
 
@@ -711,26 +729,48 @@ internal sealed class Gemma3Model
     {
         ref byte qr = ref qu[0];
         ref sbyte kr = ref kq[0];
-        var a0 = Vector256<int>.Zero;
-        var a1 = Vector256<int>.Zero;
-        var a2 = Vector256<int>.Zero;
-        var a3 = Vector256<int>.Zero;
+        int i0, i1, i2, i3;
 
-        for (int d = 0; d < headDim; d += 32)
+        if (Vnni.Use512 && (headDim & 63) == 0)
         {
-            var kv = Vector256.LoadUnsafe(ref kr, (nuint)(kBase + d));
-            a0 = Vnni.DotAccumulate(a0, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + d)), kv);
-            a1 = Vnni.DotAccumulate(a1, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + headDim + d)), kv);
-            a2 = Vnni.DotAccumulate(a2, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + 2 * headDim + d)), kv);
-            a3 = Vnni.DotAccumulate(a3, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + 3 * headDim + d)), kv);
+            // 512-bit int8 VNNI: 64 int8 MACs per accumulate (vpdpbusd on zmm), ~2x the 256-bit path.
+            var b0 = Vector512<int>.Zero;
+            var b1 = Vector512<int>.Zero;
+            var b2 = Vector512<int>.Zero;
+            var b3 = Vector512<int>.Zero;
+            for (int d = 0; d < headDim; d += 64)
+            {
+                var kv = Vector512.LoadUnsafe(ref kr, (nuint)(kBase + d));
+                b0 = Vnni.DotAccumulate512(b0, Vector512.LoadUnsafe(ref qr, (nuint)(qBase + d)), kv);
+                b1 = Vnni.DotAccumulate512(b1, Vector512.LoadUnsafe(ref qr, (nuint)(qBase + headDim + d)), kv);
+                b2 = Vnni.DotAccumulate512(b2, Vector512.LoadUnsafe(ref qr, (nuint)(qBase + 2 * headDim + d)), kv);
+                b3 = Vnni.DotAccumulate512(b3, Vector512.LoadUnsafe(ref qr, (nuint)(qBase + 3 * headDim + d)), kv);
+            }
+            i0 = Vector512.Sum(b0); i1 = Vector512.Sum(b1); i2 = Vector512.Sum(b2); i3 = Vector512.Sum(b3);
+        }
+        else
+        {
+            var a0 = Vector256<int>.Zero;
+            var a1 = Vector256<int>.Zero;
+            var a2 = Vector256<int>.Zero;
+            var a3 = Vector256<int>.Zero;
+            for (int d = 0; d < headDim; d += 32)
+            {
+                var kv = Vector256.LoadUnsafe(ref kr, (nuint)(kBase + d));
+                a0 = Vnni.DotAccumulate(a0, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + d)), kv);
+                a1 = Vnni.DotAccumulate(a1, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + headDim + d)), kv);
+                a2 = Vnni.DotAccumulate(a2, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + 2 * headDim + d)), kv);
+                a3 = Vnni.DotAccumulate(a3, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + 3 * headDim + d)), kv);
+            }
+            i0 = Vector256.Sum(a0); i1 = Vector256.Sum(a1); i2 = Vector256.Sum(a2); i3 = Vector256.Sum(a3);
         }
 
         int off = Vnni.ZeroPoint * rowSumK;
         float kScaled = scale * scaleK;
-        s0 = kScaled * sQ[sqBase + 0] * (Vector256.Sum(a0) - off);
-        s1 = kScaled * sQ[sqBase + 1] * (Vector256.Sum(a1) - off);
-        s2 = kScaled * sQ[sqBase + 2] * (Vector256.Sum(a2) - off);
-        s3 = kScaled * sQ[sqBase + 3] * (Vector256.Sum(a3) - off);
+        s0 = kScaled * sQ[sqBase + 0] * (i0 - off);
+        s1 = kScaled * sQ[sqBase + 1] * (i1 - off);
+        s2 = kScaled * sQ[sqBase + 2] * (i2 - off);
+        s3 = kScaled * sQ[sqBase + 3] * (i3 - off);
     }
 
     /// <summary>Dots the four GQA query heads at <paramref name="qBase"/> against the single shared key
@@ -781,23 +821,50 @@ internal sealed class Gemma3Model
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static void AxpyHeads4(float s0, float s1, float s2, float s3, float[] v, int vBase, float[] outArr, int outBase, int headDim)
     {
-        int w = Vector<float>.Count;
         ref float vr = ref v[vBase];
         ref float orf = ref outArr[outBase];
-
-        var vs0 = new Vector<float>(s0);
-        var vs1 = new Vector<float>(s1);
-        var vs2 = new Vector<float>(s2);
-        var vs3 = new Vector<float>(s3);
-
         int d = 0;
-        for (; d + w <= headDim; d += w)
+
+        if (Avx512F.IsSupported)
         {
-            var vv = Vector.LoadUnsafe(ref vr, (nuint)d);
-            (Vector.LoadUnsafe(ref orf, (nuint)d)                 + vv * vs0).StoreUnsafe(ref orf, (nuint)d);
-            (Vector.LoadUnsafe(ref orf, (nuint)(headDim + d))     + vv * vs1).StoreUnsafe(ref orf, (nuint)(headDim + d));
-            (Vector.LoadUnsafe(ref orf, (nuint)(2 * headDim + d)) + vv * vs2).StoreUnsafe(ref orf, (nuint)(2 * headDim + d));
-            (Vector.LoadUnsafe(ref orf, (nuint)(3 * headDim + d)) + vv * vs3).StoreUnsafe(ref orf, (nuint)(3 * headDim + d));
+            // 512-bit FMA: 16 floats/lane, fused multiply-add into the four head accumulators.
+            var p0 = Vector512.Create(s0); var p1 = Vector512.Create(s1);
+            var p2 = Vector512.Create(s2); var p3 = Vector512.Create(s3);
+            for (; d + 16 <= headDim; d += 16)
+            {
+                var vv = Vector512.LoadUnsafe(ref vr, (nuint)d);
+                Avx512F.FusedMultiplyAdd(p0, vv, Vector512.LoadUnsafe(ref orf, (nuint)d)).StoreUnsafe(ref orf, (nuint)d);
+                Avx512F.FusedMultiplyAdd(p1, vv, Vector512.LoadUnsafe(ref orf, (nuint)(headDim + d))).StoreUnsafe(ref orf, (nuint)(headDim + d));
+                Avx512F.FusedMultiplyAdd(p2, vv, Vector512.LoadUnsafe(ref orf, (nuint)(2 * headDim + d))).StoreUnsafe(ref orf, (nuint)(2 * headDim + d));
+                Avx512F.FusedMultiplyAdd(p3, vv, Vector512.LoadUnsafe(ref orf, (nuint)(3 * headDim + d))).StoreUnsafe(ref orf, (nuint)(3 * headDim + d));
+            }
+        }
+        else if (Fma.IsSupported)
+        {
+            var p0 = Vector256.Create(s0); var p1 = Vector256.Create(s1);
+            var p2 = Vector256.Create(s2); var p3 = Vector256.Create(s3);
+            for (; d + 8 <= headDim; d += 8)
+            {
+                var vv = Vector256.LoadUnsafe(ref vr, (nuint)d);
+                Fma.MultiplyAdd(p0, vv, Vector256.LoadUnsafe(ref orf, (nuint)d)).StoreUnsafe(ref orf, (nuint)d);
+                Fma.MultiplyAdd(p1, vv, Vector256.LoadUnsafe(ref orf, (nuint)(headDim + d))).StoreUnsafe(ref orf, (nuint)(headDim + d));
+                Fma.MultiplyAdd(p2, vv, Vector256.LoadUnsafe(ref orf, (nuint)(2 * headDim + d))).StoreUnsafe(ref orf, (nuint)(2 * headDim + d));
+                Fma.MultiplyAdd(p3, vv, Vector256.LoadUnsafe(ref orf, (nuint)(3 * headDim + d))).StoreUnsafe(ref orf, (nuint)(3 * headDim + d));
+            }
+        }
+        else
+        {
+            int w = Vector<float>.Count;
+            var vs0 = new Vector<float>(s0); var vs1 = new Vector<float>(s1);
+            var vs2 = new Vector<float>(s2); var vs3 = new Vector<float>(s3);
+            for (; d + w <= headDim; d += w)
+            {
+                var vv = Vector.LoadUnsafe(ref vr, (nuint)d);
+                (Vector.LoadUnsafe(ref orf, (nuint)d)                 + vv * vs0).StoreUnsafe(ref orf, (nuint)d);
+                (Vector.LoadUnsafe(ref orf, (nuint)(headDim + d))     + vv * vs1).StoreUnsafe(ref orf, (nuint)(headDim + d));
+                (Vector.LoadUnsafe(ref orf, (nuint)(2 * headDim + d)) + vv * vs2).StoreUnsafe(ref orf, (nuint)(2 * headDim + d));
+                (Vector.LoadUnsafe(ref orf, (nuint)(3 * headDim + d)) + vv * vs3).StoreUnsafe(ref orf, (nuint)(3 * headDim + d));
+            }
         }
         for (; d < headDim; d++)
         {

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -39,6 +39,12 @@ internal sealed class Gemma3Model
     private readonly Layer[] _layers;
     private readonly float[] _finalNorm;
 
+    /// <summary>When true (quantized weight modes on a VNNI host), attention scores are computed with an
+    /// int8 VNNI dot: Q/K are dynamically quantized per row so the score matmul reads K at 1 byte/element
+    /// (4x less memory than fp32 - attention is memory-bound) and uses <c>vpdpbusd</c>. The value matmul
+    /// stays fp32 (per-row V scales do not fold into an int dot).</summary>
+    private readonly bool _int8Attention;
+
     private sealed class Layer
     {
         public required float[] InputLayerNorm;
@@ -56,12 +62,13 @@ internal sealed class Gemma3Model
         public required IWeightMatrix DownProj;
     }
 
-    private Gemma3Model(Gemma3Config cfg, ushort[] embedTokens, Layer[] layers, float[] finalNorm)
+    private Gemma3Model(Gemma3Config cfg, ushort[] embedTokens, Layer[] layers, float[] finalNorm, bool int8Attention)
     {
         _cfg = cfg;
         _embedTokens = embedTokens;
         _layers = layers;
         _finalNorm = finalNorm;
+        _int8Attention = int8Attention;
         // The reference scales embeddings by sqrt(hidden_size) rounded to the embedding's bfloat16
         // dtype; reproduce that rounding so our activations track the reference exactly.
         _embedScale = FloatConversions.RoundToBFloat16(MathF.Sqrt(cfg.HiddenSize));
@@ -113,7 +120,7 @@ internal sealed class Gemma3Model
 
         var finalNorm = st.ReadFloat(prefix + "norm.weight");
 
-        return new Gemma3Model(cfg, embed, layers, finalNorm);
+        return new Gemma3Model(cfg, embed, layers, finalNorm, int8Attention: quantization != Quantization.None);
     }
 
     internal static ArrayPool<float> _pooledArray = ArrayPool<float>.Create(512000, 24);
@@ -312,18 +319,59 @@ internal sealed class Gemma3Model
     /// materializes the seq×seq score matrix, which is the memory bottleneck of the quadratic term. Other
     /// hosts use the portable head-fused materialized path <see cref="AttentionBlock"/>. (A non-chunked
     /// online softmax was measured slower: its per-element scalar <c>exp</c> loses to vectorized exp.)</summary>
-    private Task AttentionAsync(float[] q, float[] k, float[] v, float[] attnOut, int seq, int headDim, ParallelOptions parallelOptions)
+    private async Task AttentionAsync(float[] q, float[] k, float[] v, float[] attnOut, int seq, int headDim, ParallelOptions parallelOptions)
     {
         int qStride  = _cfg.NumHeads * headDim;
         int kvStride = _cfg.NumKvHeads * headDim; // == headDim (1 KV head)
         int heads    = _cfg.NumHeads;
         float scale  = _cfg.AttentionScale;
 
-        bool useFlash = !ForwardProfile.ForcePortableAttention && Fma.IsSupported && (headDim & 7) == 0;
+        bool force   = ForwardProfile.ForcePortableAttention;
+        bool useInt8 = !force && _int8Attention && Vnni.IsSupported && (headDim % 32 == 0);
+        bool useFlash = !force && Fma.IsSupported && (headDim & 7) == 0;
+
+        if (useInt8)
+        {
+            // Dynamically quantize Q (uint8, +128) and K (int8) per row once, then run the flash kernel
+            // with VNNI int8 scores. Q/K quantization is O(seq*headDim) and parallelizes over positions.
+            var qu  = ArrayPool<byte>.Shared.Rent(seq * qStride);
+            var sQ  = ArrayPool<float>.Shared.Rent(seq * heads);
+            var kq  = ArrayPool<sbyte>.Shared.Rent(seq * kvStride);
+            var sK  = ArrayPool<float>.Shared.Rent(seq);
+            var rsK = ArrayPool<int>.Shared.Rent(seq);
+            try
+            {
+                await ParallelExecution.ForAsync(0, seq, parallelOptions, (i, _) =>
+                {
+                    QuantizeQRow(q, qu, sQ, i * qStride, i * heads, heads, headDim);
+                    QuantizeKRow(k, kq, sK, rsK, i, kvStride, headDim);
+                    return ValueTask.CompletedTask;
+                }).ConfigureAwait(false);
+
+                int nb = (seq + FlashQueryBlock - 1) / FlashQueryBlock;
+                await ParallelExecution.ForAsync(0, nb, parallelOptions, (b, _) =>
+                {
+                    int q0 = b * FlashQueryBlock;
+                    int q1 = Math.Min(q0 + FlashQueryBlock, seq);
+                    FlashAttentionBlockInt8(qu, sQ, kq, sK, rsK, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+                    return ValueTask.CompletedTask;
+                }).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(qu);
+                ArrayPool<float>.Shared.Return(sQ);
+                ArrayPool<sbyte>.Shared.Return(kq);
+                ArrayPool<float>.Shared.Return(sK);
+                ArrayPool<int>.Shared.Return(rsK);
+            }
+            return;
+        }
+
         int block     = useFlash ? FlashQueryBlock : QueryBlock;
         int numBlocks = (seq + block - 1) / block;
 
-        return ParallelExecution.ForAsync(0, numBlocks, parallelOptions, (b, _) =>
+        await ParallelExecution.ForAsync(0, numBlocks, parallelOptions, (b, _) =>
         {
             int q0 = b * block;
             int q1 = Math.Min(q0 + block, seq);
@@ -336,7 +384,48 @@ internal sealed class Gemma3Model
                 AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
             }
             return ValueTask.CompletedTask;
-        });
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>Quantizes the <paramref name="heads"/> head-rows of query position <paramref name="qBase"/>
+    /// to symmetric int8 stored offset by +128 into a uint8 (the operand <c>vpdpbusd</c> expects), with a
+    /// per-(position, head) scale.</summary>
+    private static void QuantizeQRow(float[] q, byte[] qu, float[] sQ, int qBase, int sBase, int heads, int headDim)
+    {
+        for (int h = 0; h < heads; h++)
+        {
+            int b = qBase + h * headDim;
+            float amax = 0f;
+            for (int d = 0; d < headDim; d++) amax = MathF.Max(amax, MathF.Abs(q[b + d]));
+            float sc = amax > 0 ? amax / 127f : 1f;
+            float inv = 1f / sc;
+            sQ[sBase + h] = sc;
+            for (int d = 0; d < headDim; d++)
+            {
+                int v = Math.Clamp((int)MathF.Round(q[b + d] * inv), -127, 127);
+                qu[b + d] = (byte)(v + 128);
+            }
+        }
+    }
+
+    /// <summary>Quantizes key row <paramref name="i"/> to symmetric int8 with a per-row scale and the
+    /// per-row sum (used to correct the +128 offset of the uint8 query operand).</summary>
+    private static void QuantizeKRow(float[] k, sbyte[] kq, float[] sK, int[] rsK, int i, int kvStride, int headDim)
+    {
+        int b = i * kvStride;
+        float amax = 0f;
+        for (int d = 0; d < headDim; d++) amax = MathF.Max(amax, MathF.Abs(k[b + d]));
+        float sc = amax > 0 ? amax / 127f : 1f;
+        float inv = 1f / sc;
+        sK[i] = sc;
+        int sum = 0;
+        for (int d = 0; d < headDim; d++)
+        {
+            int v = Math.Clamp((int)MathF.Round(k[b + d] * inv), -127, 127);
+            kq[b + d] = (sbyte)v;
+            sum += v;
+        }
+        rsK[i] = sum;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -527,6 +616,121 @@ internal sealed class Gemma3Model
         {
             (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * iv).StoreUnsafe(ref orf, (nuint)(outBase + d));
         }
+    }
+
+    /// <summary>
+    /// Int8 variant of <see cref="FlashAttentionBlock"/>: identical block-flash structure (chunked online
+    /// softmax, no materialized scores) but the score dot is an <b>int8 VNNI</b> product over the
+    /// pre-quantized Q (uint8) and K (int8), so K is read at one byte per element (4x less memory than
+    /// fp32, and attention is memory-bound). Softmax and the value matmul stay fp32.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void FlashAttentionBlockInt8(byte[] qu, float[] sQ, sbyte[] kq, float[] sK, int[] rsK, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
+    {
+        int blk = q1 - q0;
+        float[] acc = ArrayPool<float>.Shared.Rent(blk * heads * headDim);
+        Array.Clear(acc, 0, blk * heads * headDim);
+        Span<float> mState = stackalloc float[FlashQueryBlock * 4];
+        Span<float> lState = stackalloc float[FlashQueryBlock * 4];
+        Span<float> sbuf = stackalloc float[4 * KeyChunk];
+        mState.Slice(0, blk * heads).Fill(float.NegativeInfinity);
+        lState.Slice(0, blk * heads).Clear();
+
+        for (int kb = 0; kb < q1; kb += KeyChunk)
+        {
+            int kEnd = Math.Min(kb + KeyChunk, q1);
+            for (int local = 0; local < blk; local++)
+            {
+                int qi = q0 + local;
+                if (kb > qi) continue;
+                int jHi = Math.Min(kEnd, qi + 1);
+                int cnt = jHi - kb;
+                int qB = qi * qStride;
+                int sqB = qi * heads;
+                int accLocal = local * heads * headDim;
+
+                for (int jj = 0; jj < cnt; jj++)
+                {
+                    int key = kb + jj;
+                    ScoreHeads4Int8(qu, qB, sQ, sqB, kq, key * kvStride, sK[key], rsK[key], headDim, scale,
+                                    out float s0, out float s1, out float s2, out float s3);
+                    sbuf[0 * KeyChunk + jj] = s0;
+                    sbuf[1 * KeyChunk + jj] = s1;
+                    sbuf[2 * KeyChunk + jj] = s2;
+                    sbuf[3 * KeyChunk + jj] = s3;
+                }
+
+                for (int head = 0; head < heads; head++)
+                {
+                    var s = sbuf.Slice(head * KeyChunk, cnt);
+                    float bmax = TensorPrimitives.Max(s);
+                    int st = local * heads + head;
+                    float mPrev = mState[st];
+                    float mNew = MathF.Max(mPrev, bmax);
+
+                    TensorPrimitives.Subtract(s, mNew, s);
+                    TensorPrimitives.Exp(s, s);
+                    float psum = TensorPrimitives.Sum(s);
+                    float corr = float.IsNegativeInfinity(mPrev) ? 0f : MathF.Exp(mPrev - mNew);
+
+                    lState[st] = lState[st] * corr + psum;
+                    if (corr != 1f)
+                    {
+                        ScaleInPlaceFma(acc, accLocal + head * headDim, corr, headDim);
+                    }
+                    mState[st] = mNew;
+                }
+
+                for (int jj = 0; jj < cnt; jj++)
+                {
+                    AxpyHeads4(sbuf[0 * KeyChunk + jj], sbuf[1 * KeyChunk + jj], sbuf[2 * KeyChunk + jj], sbuf[3 * KeyChunk + jj],
+                               v, (kb + jj) * kvStride, acc, accLocal, headDim);
+                }
+            }
+        }
+
+        for (int local = 0; local < blk; local++)
+        {
+            for (int head = 0; head < heads; head++)
+            {
+                int st = local * heads + head;
+                float inv = lState[st] > 0f ? 1f / lState[st] : 0f;
+                ScaleTo(acc, st * headDim, attnOut, (q0 + local) * qStride + head * headDim, inv, headDim);
+            }
+        }
+
+        ArrayPool<float>.Shared.Return(acc);
+    }
+
+    /// <summary>Int8 VNNI scores for the four GQA query heads against one shared key: <c>vpdpbusd</c> of the
+    /// uint8 query rows and the int8 key row, with the +128 offset corrected by the key's row sum, then
+    /// scaled by <c>scaleQ_head * scaleK * attnScale</c>.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ScoreHeads4Int8(byte[] qu, int qBase, float[] sQ, int sqBase, sbyte[] kq, int kBase, float scaleK, int rowSumK, int headDim, float scale,
+                                        out float s0, out float s1, out float s2, out float s3)
+    {
+        ref byte qr = ref qu[0];
+        ref sbyte kr = ref kq[0];
+        var a0 = Vector256<int>.Zero;
+        var a1 = Vector256<int>.Zero;
+        var a2 = Vector256<int>.Zero;
+        var a3 = Vector256<int>.Zero;
+
+        for (int d = 0; d < headDim; d += 32)
+        {
+            var kv = Vector256.LoadUnsafe(ref kr, (nuint)(kBase + d));
+            a0 = Vnni.DotAccumulate(a0, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + d)), kv);
+            a1 = Vnni.DotAccumulate(a1, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + headDim + d)), kv);
+            a2 = Vnni.DotAccumulate(a2, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + 2 * headDim + d)), kv);
+            a3 = Vnni.DotAccumulate(a3, Vector256.LoadUnsafe(ref qr, (nuint)(qBase + 3 * headDim + d)), kv);
+        }
+
+        int off = Vnni.ZeroPoint * rowSumK;
+        float kScaled = scale * scaleK;
+        s0 = kScaled * sQ[sqBase + 0] * (Vector256.Sum(a0) - off);
+        s1 = kScaled * sQ[sqBase + 1] * (Vector256.Sum(a1) - off);
+        s2 = kScaled * sQ[sqBase + 2] * (Vector256.Sum(a2) - off);
+        s3 = kScaled * sQ[sqBase + 3] * (Vector256.Sum(a3) - off);
     }
 
     /// <summary>Dots the four GQA query heads at <paramref name="qBase"/> against the single shared key

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -212,9 +212,8 @@ internal sealed class Gemma3Model
                 await layer.UpProj.MultiplyAsync(normed, up, seq, parallelOptions).ConfigureAwait(false);
                 ForwardProfile.Stop("mlp_proj", ts);
 
-                int ffLen = seq * _cfg.IntermediateSize;
                 ts = ForwardProfile.Start();
-                Ops.GeGluInPlace(gate.AsSpan(0, ffLen), up.AsSpan(0, ffLen));
+                await Ops.GeGluAsync(gate, up, seq, _cfg.IntermediateSize, parallelOptions).ConfigureAwait(false);
                 ForwardProfile.Stop("geglu", ts);
 
                 ts = ForwardProfile.Start();

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Numerics;
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using SentenceTransformers;
@@ -310,6 +311,12 @@ internal sealed class Gemma3Model
         int heads    = _cfg.NumHeads;
         float scale  = _cfg.AttentionScale;
 
+        // The fused score/value kernels are specialized for this model's 4 query heads.
+        if (heads != 4)
+        {
+            throw new NotSupportedException($"Fused attention expects 4 query heads, got {heads}.");
+        }
+
         int numBlocks = (seq + QueryBlock - 1) / QueryBlock;
 
         return ParallelExecution.ForAsync(0, numBlocks, parallelOptions, (b, _) =>
@@ -322,11 +329,13 @@ internal sealed class Gemma3Model
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    /// <summary>Computes attention output for the query positions <c>[q0, q1)</c> across all heads.
-    /// Key/value vectors are loaded in the outer loop so each is reused across every query in the block
-    /// and every head (the single shared KV head), which keeps K/V cache-resident during reuse. The
-    /// per-(query, head) softmax and the j-ordered value accumulation are unchanged, so the output is
-    /// bit-identical to a naive per-row implementation.</summary>
+    /// <summary>Computes attention output for the query positions <c>[q0, q1)</c> across all 4 heads.
+    /// Key/value vectors are loaded in the outer loop so each is reused across every query in the block,
+    /// and the four GQA query heads are fused into a single SIMD pass per key/value (see
+    /// <see cref="ScoreHeads4"/>/<see cref="AxpyHeads4"/>), keeping K/V cache-resident during reuse and
+    /// cutting the dot/axpy call count ~4x. The per-(query, head) softmax and the j-ordered value
+    /// accumulation are preserved; only the in-dot lane reassociation differs from a scalar dot, so the
+    /// output matches the reference to float tolerance.</summary>
     private static void AttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
         int blk     = q1 - q0;
@@ -334,21 +343,23 @@ internal sealed class Gemma3Model
         int perQ    = heads * nKeys;      // scores stride per query in the block
         float[] scores = ArrayPool<float>.Shared.Rent(blk * perQ);
 
-        // --- scores: scale * (q_head . k_j), key-outer so k_j is read once and reused blk*heads times ---
+        // --- scores: scale * (q_head . k_j). Key-outer so k_j is read once and reused across the whole
+        //     block; the 4 GQA query heads are dotted against the shared k_j in a single SIMD pass
+        //     (4 accumulators), so k_j is streamed once per (key, query) instead of once per head. ---
         for (int j = 0; j < nKeys; j++)
         {
-            var kSpan = new ReadOnlySpan<float>(k, j * kvStride, headDim);
+            int kBase = j * kvStride;
             for (int local = 0; local < blk; local++)
             {
                 int qi = q0 + local;
                 if (j > qi) continue;     // causal mask
                 int qBase  = qi * qStride;
                 int sBase  = local * perQ;
-                for (int head = 0; head < heads; head++)
-                {
-                    var qSpan = new ReadOnlySpan<float>(q, qBase + head * headDim, headDim);
-                    scores[sBase + head * nKeys + j] = TensorPrimitives.Dot(qSpan, kSpan) * scale;
-                }
+                ScoreHeads4(q, qBase, k, kBase, headDim, scale, out var s0, out var s1, out var s2, out var s3);
+                scores[sBase + 0 * nKeys + j] = s0;
+                scores[sBase + 1 * nKeys + j] = s1;
+                scores[sBase + 2 * nKeys + j] = s2;
+                scores[sBase + 3 * nKeys + j] = s3;
             }
         }
 
@@ -376,23 +387,99 @@ internal sealed class Gemma3Model
 
         for (int j = 0; j < nKeys; j++)
         {
-            var vSpan = new ReadOnlySpan<float>(v, j * kvStride, headDim);
+            int vBase = j * kvStride;
             for (int local = 0; local < blk; local++)
             {
                 int qi = q0 + local;
                 if (j > qi) continue;
                 int qBase = qi * qStride;
                 int sBase = local * perQ;
-                for (int head = 0; head < heads; head++)
-                {
-                    float w = scores[sBase + head * nKeys + j];
-                    var outSpan = new Span<float>(attnOut, qBase + head * headDim, headDim);
-                    TensorPrimitives.MultiplyAdd(vSpan, w, outSpan, outSpan);
-                }
+                AxpyHeads4(
+                    scores[sBase + 0 * nKeys + j],
+                    scores[sBase + 1 * nKeys + j],
+                    scores[sBase + 2 * nKeys + j],
+                    scores[sBase + 3 * nKeys + j],
+                    v, vBase, attnOut, qBase, headDim);
             }
         }
 
         ArrayPool<float>.Shared.Return(scores);
+    }
+
+    /// <summary>Dots the four GQA query heads at <paramref name="qBase"/> against the single shared key
+    /// vector at <paramref name="kBase"/> in one pass over <paramref name="headDim"/>, using
+    /// platform-width <see cref="Vector{T}"/> (256-bit on AVX2, 128-bit on NEON/SSE) so the key is read
+    /// once for all four heads. Reassociates the sum across SIMD lanes vs a scalar dot, so results match
+    /// the reference to float tolerance rather than bit-exactly.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void ScoreHeads4(float[] q, int qBase, float[] k, int kBase, int headDim, float scale, out float s0, out float s1, out float s2, out float s3)
+    {
+        int w = Vector<float>.Count;
+        ref float qr = ref q[qBase];
+        ref float kr = ref k[kBase];
+
+        var a0 = Vector<float>.Zero;
+        var a1 = Vector<float>.Zero;
+        var a2 = Vector<float>.Zero;
+        var a3 = Vector<float>.Zero;
+
+        int d = 0;
+        for (; d + w <= headDim; d += w)
+        {
+            var kv = Vector.LoadUnsafe(ref kr, (nuint)d);
+            a0 += Vector.LoadUnsafe(ref qr, (nuint)d) * kv;
+            a1 += Vector.LoadUnsafe(ref qr, (nuint)(headDim + d)) * kv;
+            a2 += Vector.LoadUnsafe(ref qr, (nuint)(2 * headDim + d)) * kv;
+            a3 += Vector.LoadUnsafe(ref qr, (nuint)(3 * headDim + d)) * kv;
+        }
+
+        float r0 = Vector.Sum(a0), r1 = Vector.Sum(a1), r2 = Vector.Sum(a2), r3 = Vector.Sum(a3);
+        for (; d < headDim; d++) // tail (headDim is a multiple of the vector width here, so usually empty)
+        {
+            float kd = Unsafe.Add(ref kr, d);
+            r0 += Unsafe.Add(ref qr, d) * kd;
+            r1 += Unsafe.Add(ref qr, headDim + d) * kd;
+            r2 += Unsafe.Add(ref qr, 2 * headDim + d) * kd;
+            r3 += Unsafe.Add(ref qr, 3 * headDim + d) * kd;
+        }
+
+        s0 = r0 * scale;
+        s1 = r1 * scale;
+        s2 = r2 * scale;
+        s3 = r3 * scale;
+    }
+
+    /// <summary>Accumulates <c>out_head += weight_head * v_j</c> for all four GQA heads in one pass over
+    /// <paramref name="headDim"/>, reading the shared value vector once for all four heads.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void AxpyHeads4(float s0, float s1, float s2, float s3, float[] v, int vBase, float[] outArr, int outBase, int headDim)
+    {
+        int w = Vector<float>.Count;
+        ref float vr = ref v[vBase];
+        ref float orf = ref outArr[outBase];
+
+        var vs0 = new Vector<float>(s0);
+        var vs1 = new Vector<float>(s1);
+        var vs2 = new Vector<float>(s2);
+        var vs3 = new Vector<float>(s3);
+
+        int d = 0;
+        for (; d + w <= headDim; d += w)
+        {
+            var vv = Vector.LoadUnsafe(ref vr, (nuint)d);
+            (Vector.LoadUnsafe(ref orf, (nuint)d)                 + vv * vs0).StoreUnsafe(ref orf, (nuint)d);
+            (Vector.LoadUnsafe(ref orf, (nuint)(headDim + d))     + vv * vs1).StoreUnsafe(ref orf, (nuint)(headDim + d));
+            (Vector.LoadUnsafe(ref orf, (nuint)(2 * headDim + d)) + vv * vs2).StoreUnsafe(ref orf, (nuint)(2 * headDim + d));
+            (Vector.LoadUnsafe(ref orf, (nuint)(3 * headDim + d)) + vv * vs3).StoreUnsafe(ref orf, (nuint)(3 * headDim + d));
+        }
+        for (; d < headDim; d++)
+        {
+            float vd = Unsafe.Add(ref vr, d);
+            Unsafe.Add(ref orf, d)                 += s0 * vd;
+            Unsafe.Add(ref orf, headDim + d)       += s1 * vd;
+            Unsafe.Add(ref orf, 2 * headDim + d)   += s2 * vd;
+            Unsafe.Add(ref orf, 3 * headDim + d)   += s3 * vd;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -339,15 +339,12 @@ internal sealed class Gemma3Model
             var kq  = ArrayPool<sbyte>.Shared.Rent(seq * kvStride);
             var sK  = ArrayPool<float>.Shared.Rent(seq);
             var rsK = ArrayPool<int>.Shared.Rent(seq);
-            var vq  = ArrayPool<sbyte>.Shared.Rent(seq * kvStride);
-            var sV  = ArrayPool<float>.Shared.Rent(seq);
             try
             {
                 await ParallelExecution.ForAsync(0, seq, parallelOptions, (i, _) =>
                 {
                     QuantizeQRow(q, qu, sQ, i * qStride, i * heads, heads, headDim);
                     QuantizeKRow(k, kq, sK, rsK, i, kvStride, headDim);
-                    QuantizeVRow(v, vq, sV, i, kvStride, headDim);
                     return ValueTask.CompletedTask;
                 }).ConfigureAwait(false);
 
@@ -356,7 +353,7 @@ internal sealed class Gemma3Model
                 {
                     int q0 = b * FlashQueryBlock;
                     int q1 = Math.Min(q0 + FlashQueryBlock, seq);
-                    FlashAttentionBlockInt8(qu, sQ, kq, sK, rsK, vq, sV, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+                    FlashAttentionBlockInt8(qu, sQ, kq, sK, rsK, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
                     return ValueTask.CompletedTask;
                 }).ConfigureAwait(false);
             }
@@ -367,8 +364,6 @@ internal sealed class Gemma3Model
                 ArrayPool<sbyte>.Shared.Return(kq);
                 ArrayPool<float>.Shared.Return(sK);
                 ArrayPool<int>.Shared.Return(rsK);
-                ArrayPool<sbyte>.Shared.Return(vq);
-                ArrayPool<float>.Shared.Return(sV);
             }
             return;
         }
@@ -431,22 +426,6 @@ internal sealed class Gemma3Model
             sum += v;
         }
         rsK[i] = sum;
-    }
-
-    /// <summary>Quantizes value row <paramref name="i"/> to symmetric int8 with a per-row scale, so the
-    /// value matmul reads V at one byte/element (4x less memory). The fp probability folds the scale in.</summary>
-    private static void QuantizeVRow(float[] v, sbyte[] vq, float[] sV, int i, int kvStride, int headDim)
-    {
-        int b = i * kvStride;
-        float amax = 0f;
-        for (int d = 0; d < headDim; d++) amax = MathF.Max(amax, MathF.Abs(v[b + d]));
-        float sc = amax > 0 ? amax / 127f : 1f;
-        float inv = 1f / sc;
-        sV[i] = sc;
-        for (int d = 0; d < headDim; d++)
-        {
-            vq[b + d] = (sbyte)Math.Clamp((int)MathF.Round(v[b + d] * inv), -127, 127);
-        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -646,7 +625,7 @@ internal sealed class Gemma3Model
     /// fp32, and attention is memory-bound). Softmax and the value matmul stay fp32.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private static void FlashAttentionBlockInt8(byte[] qu, float[] sQ, sbyte[] kq, float[] sK, int[] rsK, sbyte[] vq, float[] sV, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
+    private static void FlashAttentionBlockInt8(byte[] qu, float[] sQ, sbyte[] kq, float[] sK, int[] rsK, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
         int blk = q1 - q0;
         float[] acc = ArrayPool<float>.Shared.Rent(blk * heads * headDim);
@@ -704,10 +683,8 @@ internal sealed class Gemma3Model
 
                 for (int jj = 0; jj < cnt; jj++)
                 {
-                    int key = kb + jj;
-                    float sv = sV[key]; // per-row value scale folded into each head's probability
-                    AxpyHeads4Int8(sbuf[0 * KeyChunk + jj] * sv, sbuf[1 * KeyChunk + jj] * sv, sbuf[2 * KeyChunk + jj] * sv, sbuf[3 * KeyChunk + jj] * sv,
-                                   vq, key * kvStride, acc, accLocal, headDim);
+                    AxpyHeads4(sbuf[0 * KeyChunk + jj], sbuf[1 * KeyChunk + jj], sbuf[2 * KeyChunk + jj], sbuf[3 * KeyChunk + jj],
+                               v, (kb + jj) * kvStride, acc, accLocal, headDim);
                 }
             }
         }
@@ -723,32 +700,6 @@ internal sealed class Gemma3Model
         }
 
         ArrayPool<float>.Shared.Return(acc);
-    }
-
-    /// <summary>Value accumulation for all 4 heads from an int8 value row: widens 8 int8 values to float
-    /// and FMAs <c>weight_head * v</c> into each head's accumulator. V is read once (1 byte/element) for
-    /// all four heads.</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void AxpyHeads4Int8(float w0, float w1, float w2, float w3, sbyte[] vq, int vBase, float[] acc, int accBase, int headDim)
-    {
-        ref sbyte vr = ref vq[0];
-        ref float ar = ref acc[0];
-        var p0 = Vector256.Create(w0);
-        var p1 = Vector256.Create(w1);
-        var p2 = Vector256.Create(w2);
-        var p3 = Vector256.Create(w3);
-        int o1 = accBase + headDim, o2 = accBase + 2 * headDim, o3 = accBase + 3 * headDim;
-        for (int d = 0; d < headDim; d += 8)
-        {
-            // Read exactly 8 int8 values (a long) and sign-extend to 8 int32 -> 8 float (no over-read).
-            long bits = Unsafe.ReadUnaligned<long>(ref Unsafe.As<sbyte, byte>(ref Unsafe.Add(ref vr, vBase + d)));
-            var vi = Avx2.ConvertToVector256Int32(Vector128.CreateScalarUnsafe(bits).AsSByte());
-            var vf = Vector256.ConvertToSingle(vi);
-            Fma.MultiplyAdd(p0, vf, Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d))).StoreUnsafe(ref ar, (nuint)(accBase + d));
-            Fma.MultiplyAdd(p1, vf, Vector256.LoadUnsafe(ref ar, (nuint)(o1 + d))).StoreUnsafe(ref ar, (nuint)(o1 + d));
-            Fma.MultiplyAdd(p2, vf, Vector256.LoadUnsafe(ref ar, (nuint)(o2 + d))).StoreUnsafe(ref ar, (nuint)(o2 + d));
-            Fma.MultiplyAdd(p3, vf, Vector256.LoadUnsafe(ref ar, (nuint)(o3 + d))).StoreUnsafe(ref ar, (nuint)(o3 + d));
-        }
     }
 
     /// <summary>Int8 VNNI scores for the four GQA query heads against one shared key: <c>vpdpbusd</c> of the

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -290,10 +290,19 @@ internal sealed class Gemma3Model
         }
     }
 
+    /// <summary>Query positions processed together per attention block. The shared single KV head's
+    /// key/value vectors are loaded once per key and reused across all <see cref="QueryBlock"/> queries
+    /// × all query heads, so each cache line of K/V services <c>QueryBlock * NumHeads</c> dot products
+    /// instead of one. Keeps the per-block score scratch (<c>QueryBlock * heads * seq</c> floats) and the
+    /// queries it sweeps comfortably cache-resident.</summary>
+    private const int QueryBlock = 8;
+
     /// <summary>Causal grouped-query attention. The single KV head is shared by all query heads.
-    /// Parallelizes over query positions via <see cref="ParallelExecution.ForAsync"/>: per-index
-    /// <c>Parallel.ForAsync</c> dispatch gives dynamic load balancing for the triangular causal work
-    /// when <see cref="ParallelExecution.Enabled"/>, and runs single-threaded otherwise.</summary>
+    /// Parallelizes over <see cref="QueryBlock"/>-sized blocks of query positions via
+    /// <see cref="ParallelExecution.ForAsync"/> (dynamic load balancing for the triangular causal work
+    /// when the caller requests parallelism, single-threaded otherwise). The math is identical to a
+    /// per-(query, head) loop - the keys/values are merely streamed in an order that reuses each K/V
+    /// vector across the whole block, which is the dominant cost of the quadratic attention term.</summary>
     private Task AttentionAsync(float[] q, float[] k, float[] v, float[] attnOut, int seq, int headDim, ParallelOptions parallelOptions)
     {
         int qStride  = _cfg.NumHeads * headDim;
@@ -301,38 +310,85 @@ internal sealed class Gemma3Model
         int heads    = _cfg.NumHeads;
         float scale  = _cfg.AttentionScale;
 
-        return ParallelExecution.ForAsync(0, seq, parallelOptions, (i, _) =>
+        int numBlocks = (seq + QueryBlock - 1) / QueryBlock;
+
+        return ParallelExecution.ForAsync(0, numBlocks, parallelOptions, (b, _) =>
         {
-            AttentionRow(q, k, v, attnOut, i, headDim, qStride, kvStride, heads, scale);
+            int q0 = b * QueryBlock;
+            int q1 = Math.Min(q0 + QueryBlock, seq);
+            AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
             return ValueTask.CompletedTask;
         });
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
-    /// <summary>Computes attention output for one query position across all heads. Synchronous so the
-    /// pooled score buffer and spans stay out of an async body. Score buffers come from a pool (no
-    /// per-call allocations); the value accumulation is a vectorized scalar*vector add.</summary>
-    private static void AttentionRow(float[] q, float[] k, float[] v, float[] attnOut, int i, int headDim, int qStride, int kvStride, int heads, float scale)
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    /// <summary>Computes attention output for the query positions <c>[q0, q1)</c> across all heads.
+    /// Key/value vectors are loaded in the outer loop so each is reused across every query in the block
+    /// and every head (the single shared KV head), which keeps K/V cache-resident during reuse. The
+    /// per-(query, head) softmax and the j-ordered value accumulation are unchanged, so the output is
+    /// bit-identical to a naive per-row implementation.</summary>
+    private static void AttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
-        float[] scores = ArrayPool<float>.Shared.Rent(i + 1);
+        int blk     = q1 - q0;
+        int nKeys   = q1;                 // keys 0..q1-1 are the most any query in this block attends to
+        int perQ    = heads * nKeys;      // scores stride per query in the block
+        float[] scores = ArrayPool<float>.Shared.Rent(blk * perQ);
 
-        for (int head = 0; head < heads; head++)
+        // --- scores: scale * (q_head . k_j), key-outer so k_j is read once and reused blk*heads times ---
+        for (int j = 0; j < nKeys; j++)
         {
-            var qSpan = new ReadOnlySpan<float>(q, i * qStride + head * headDim, headDim);
-
-            for (int j = 0; j <= i; j++)
+            var kSpan = new ReadOnlySpan<float>(k, j * kvStride, headDim);
+            for (int local = 0; local < blk; local++)
             {
-                scores[j] = TensorPrimitives.Dot(qSpan, new ReadOnlySpan<float>(k, j * kvStride, headDim)) * scale;
+                int qi = q0 + local;
+                if (j > qi) continue;     // causal mask
+                int qBase  = qi * qStride;
+                int sBase  = local * perQ;
+                for (int head = 0; head < heads; head++)
+                {
+                    var qSpan = new ReadOnlySpan<float>(q, qBase + head * headDim, headDim);
+                    scores[sBase + head * nKeys + j] = TensorPrimitives.Dot(qSpan, kSpan) * scale;
+                }
             }
+        }
 
-            Ops.SoftmaxInPlace(scores, i + 1);
-
-            var outSpan = new Span<float>(attnOut, i * qStride + head * headDim, headDim);
-            outSpan.Clear();
-            for (int j = 0; j <= i; j++)
+        // --- per-(query, head) softmax over its causal prefix ---
+        for (int local = 0; local < blk; local++)
+        {
+            int qi = q0 + local;
+            int sBase = local * perQ;
+            for (int head = 0; head < heads; head++)
             {
-                // outSpan += scores[j] * v[j]
-                TensorPrimitives.MultiplyAdd(new ReadOnlySpan<float>(v, j * kvStride, headDim), scores[j], outSpan, outSpan);
+                Ops.SoftmaxInPlace(scores.AsSpan(sBase + head * nKeys, qi + 1), qi + 1);
+            }
+        }
+
+        // --- value accumulation: out += scores[j] * v_j, key-outer so v_j is reused blk*heads times.
+        //     For each (query, head) the j sum runs 0..qi in order, identical to the per-row path. ---
+        for (int local = 0; local < blk; local++)
+        {
+            int qi = q0 + local;
+            for (int head = 0; head < heads; head++)
+            {
+                new Span<float>(attnOut, qi * qStride + head * headDim, headDim).Clear();
+            }
+        }
+
+        for (int j = 0; j < nKeys; j++)
+        {
+            var vSpan = new ReadOnlySpan<float>(v, j * kvStride, headDim);
+            for (int local = 0; local < blk; local++)
+            {
+                int qi = q0 + local;
+                if (j > qi) continue;
+                int qBase = qi * qStride;
+                int sBase = local * perQ;
+                for (int head = 0; head < heads; head++)
+                {
+                    float w = scores[sBase + head * nKeys + j];
+                    var outSpan = new Span<float>(attnOut, qBase + head * headDim, headDim);
+                    TensorPrimitives.MultiplyAdd(vSpan, w, outSpan, outSpan);
+                }
             }
         }
 

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -292,21 +292,26 @@ internal sealed class Gemma3Model
         }
     }
 
-    /// <summary>Query positions processed together per attention block. The shared single KV head's
-    /// key/value vectors are loaded once per key and reused across all <see cref="QueryBlock"/> queries
-    /// × all query heads, so each cache line of K/V services <c>QueryBlock * NumHeads</c> dot products
-    /// instead of one. Keeps the per-block score scratch (<c>QueryBlock * heads * seq</c> floats) and the
-    /// queries it sweeps comfortably cache-resident.</summary>
+    /// <summary>Query positions processed together per attention block.</summary>
     private const int QueryBlock = 16;
 
+    /// <summary>Key chunk for the block-flash kernel: keys are processed in <see cref="KeyChunk"/>-sized
+    /// tiles so the per-query score scratch (one chunk) stays in L1 and <c>exp</c> stays vectorized,
+    /// while the K/V chunk is reused across all <see cref="FlashQueryBlock"/> queries of the block.</summary>
+    private const int KeyChunk = 256;
+
+    /// <summary>Query block for the block-flash kernel. Larger than <see cref="QueryBlock"/> because the
+    /// flash path's scratch no longer scales with it (only the per-query running state does), so each
+    /// loaded K/V chunk is reused across more queries - cutting K/V memory traffic, the bottleneck of the
+    /// quadratic term.</summary>
+    private const int FlashQueryBlock = 64;
+
     /// <summary>Causal grouped-query attention. The single KV head is shared by all query heads.
-    /// Parallelizes over <see cref="QueryBlock"/>-sized blocks of query positions via
-    /// <see cref="ParallelExecution.ForAsync"/> (dynamic load balancing for the triangular causal work).
-    /// Each block computes scores tile-by-tile, applies a vectorized softmax, then the value sum, reusing
-    /// each key/value vector across the whole block (the dominant cost of the quadratic attention term).
-    /// A streaming online-softmax (flash) variant was measured slower here: on CPU the per-element scalar
-    /// <c>exp</c> it requires loses badly to the materialized path's vectorized <c>TensorPrimitives.Exp</c>
-    /// over whole score rows.</summary>
+    /// On x64 each query block runs <see cref="FlashAttentionBlock"/> - a block-wise flash attention that
+    /// streams keys in L1-sized chunks with an online softmax (vectorized <c>exp</c> per chunk) and never
+    /// materializes the seq×seq score matrix, which is the memory bottleneck of the quadratic term. Other
+    /// hosts use the portable head-fused materialized path <see cref="AttentionBlock"/>. (A non-chunked
+    /// online softmax was measured slower: its per-element scalar <c>exp</c> loses to vectorized exp.)</summary>
     private Task AttentionAsync(float[] q, float[] k, float[] v, float[] attnOut, int seq, int headDim, ParallelOptions parallelOptions)
     {
         int qStride  = _cfg.NumHeads * headDim;
@@ -314,13 +319,22 @@ internal sealed class Gemma3Model
         int heads    = _cfg.NumHeads;
         float scale  = _cfg.AttentionScale;
 
-        int numBlocks = (seq + QueryBlock - 1) / QueryBlock;
+        bool useFlash = !ForwardProfile.ForcePortableAttention && Fma.IsSupported && (headDim & 7) == 0;
+        int block     = useFlash ? FlashQueryBlock : QueryBlock;
+        int numBlocks = (seq + block - 1) / block;
 
         return ParallelExecution.ForAsync(0, numBlocks, parallelOptions, (b, _) =>
         {
-            int q0 = b * QueryBlock;
-            int q1 = Math.Min(q0 + QueryBlock, seq);
-            AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+            int q0 = b * block;
+            int q1 = Math.Min(q0 + block, seq);
+            if (useFlash)
+            {
+                FlashAttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+            }
+            else
+            {
+                AttentionBlock(q, k, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+            }
             return ValueTask.CompletedTask;
         });
     }
@@ -399,6 +413,135 @@ internal sealed class Gemma3Model
         }
 
         ArrayPool<float>.Shared.Return(scores);
+    }
+
+    /// <summary>
+    /// Block-wise flash attention for the query positions <c>[q0, q1)</c> on x64. Keys are streamed in
+    /// <see cref="KeyChunk"/>-sized tiles; for each (query, chunk) the chunk's scores are computed into an
+    /// L1 buffer, exponentiated with a <b>vectorized</b> <c>exp</c>, and folded into a per-query
+    /// online-softmax running max / denominator / value accumulator. The seq×seq score matrix is never
+    /// materialized (its memory traffic was the quadratic term's bottleneck), and each K/V chunk is reused
+    /// across all queries in the (large) block. Float results match the reference to tolerance
+    /// (online-softmax + FMA/lane reassociation only).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void FlashAttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
+    {
+        int blk = q1 - q0;
+        float[] acc = ArrayPool<float>.Shared.Rent(blk * headDim);
+        Span<float> mState = stackalloc float[FlashQueryBlock];
+        Span<float> lState = stackalloc float[FlashQueryBlock];
+        Span<float> sbuf = stackalloc float[KeyChunk];
+
+        ref float qr = ref q[0];
+        ref float kr = ref k[0];
+        ref float vr = ref v[0];
+
+        for (int head = 0; head < heads; head++)
+        {
+            int headOff = head * headDim;
+            Array.Clear(acc, 0, blk * headDim);
+            mState.Slice(0, blk).Fill(float.NegativeInfinity);
+            lState.Slice(0, blk).Clear();
+
+            for (int kb = 0; kb < q1; kb += KeyChunk)
+            {
+                int kEnd = Math.Min(kb + KeyChunk, q1);
+                for (int local = 0; local < blk; local++)
+                {
+                    int qi = q0 + local;
+                    if (kb > qi) continue;                 // whole chunk is causally masked for this query
+                    int jHi = Math.Min(kEnd, qi + 1);
+                    int cnt = jHi - kb;
+                    int qb = qi * qStride + headOff;
+
+                    for (int jj = 0; jj < cnt; jj++)
+                    {
+                        sbuf[jj] = DotFma(ref qr, qb, ref kr, (kb + jj) * kvStride, headDim) * scale;
+                    }
+
+                    var s = sbuf.Slice(0, cnt);
+                    float bmax = TensorPrimitives.Max(s);
+                    float mPrev = mState[local];
+                    float mNew = MathF.Max(mPrev, bmax);
+
+                    TensorPrimitives.Subtract(s, mNew, s);  // s -= mNew
+                    TensorPrimitives.Exp(s, s);             // s = exp(s - mNew)  (vectorized)
+                    float psum = TensorPrimitives.Sum(s);
+                    float corr = float.IsNegativeInfinity(mPrev) ? 0f : MathF.Exp(mPrev - mNew);
+
+                    lState[local] = lState[local] * corr + psum;
+                    int accBase = local * headDim;
+                    if (corr != 1f)
+                    {
+                        ScaleInPlaceFma(acc, accBase, corr, headDim);   // rescale prior contributions to new max
+                    }
+                    for (int jj = 0; jj < cnt; jj++)
+                    {
+                        AxpyFma(acc, accBase, ref vr, (kb + jj) * kvStride, s[jj], headDim); // acc += p_jj * V_j
+                    }
+                    mState[local] = mNew;
+                }
+            }
+
+            for (int local = 0; local < blk; local++)
+            {
+                float inv = lState[local] > 0f ? 1f / lState[local] : 0f;
+                ScaleTo(acc, local * headDim, attnOut, (q0 + local) * qStride + headOff, inv, headDim);
+            }
+        }
+
+        ArrayPool<float>.Shared.Return(acc);
+    }
+
+    /// <summary>256-bit FMA dot product over <paramref name="dim"/> (a multiple of 8).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float DotFma(ref float a, int aOff, ref float b, int bOff, int dim)
+    {
+        var acc = Vector256<float>.Zero;
+        for (int d = 0; d < dim; d += 8)
+        {
+            acc = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref a, (nuint)(aOff + d)), Vector256.LoadUnsafe(ref b, (nuint)(bOff + d)), acc);
+        }
+        return Vector256.Sum(acc);
+    }
+
+    /// <summary><c>acc += p * v</c> over <paramref name="dim"/> (FMA).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AxpyFma(float[] acc, int accBase, ref float v, int vOff, float p, int dim)
+    {
+        ref float ar = ref acc[0];
+        var pv = Vector256.Create(p);
+        for (int d = 0; d < dim; d += 8)
+        {
+            Fma.MultiplyAdd(pv, Vector256.LoadUnsafe(ref v, (nuint)(vOff + d)), Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)))
+               .StoreUnsafe(ref ar, (nuint)(accBase + d));
+        }
+    }
+
+    /// <summary><c>acc *= corr</c> over <paramref name="dim"/> (online-softmax rescale).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ScaleInPlaceFma(float[] acc, int accBase, float corr, int dim)
+    {
+        ref float ar = ref acc[0];
+        var cv = Vector256.Create(corr);
+        for (int d = 0; d < dim; d += 8)
+        {
+            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * cv).StoreUnsafe(ref ar, (nuint)(accBase + d));
+        }
+    }
+
+    /// <summary><c>out = acc * inv</c> over <paramref name="dim"/> (final softmax normalization).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ScaleTo(float[] acc, int accBase, float[] outArr, int outBase, float inv, int dim)
+    {
+        ref float ar = ref acc[0];
+        ref float orf = ref outArr[0];
+        var iv = Vector256.Create(inv);
+        for (int d = 0; d < dim; d += 8)
+        {
+            (Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)) * iv).StoreUnsafe(ref orf, (nuint)(outBase + d));
+        }
     }
 
     /// <summary>Dots the four GQA query heads at <paramref name="qBase"/> against the single shared key

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -304,7 +304,7 @@ internal sealed class Gemma3Model
     /// flash path's scratch no longer scales with it (only the per-query running state does), so each
     /// loaded K/V chunk is reused across more queries - cutting K/V memory traffic, the bottleneck of the
     /// quadratic term.</summary>
-    private const int FlashQueryBlock = 64;
+    private const int FlashQueryBlock = 32;
 
     /// <summary>Causal grouped-query attention. The single KV head is shared by all query heads.
     /// On x64 each query block runs <see cref="FlashAttentionBlock"/> - a block-wise flash attention that
@@ -427,96 +427,81 @@ internal sealed class Gemma3Model
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static void FlashAttentionBlock(float[] q, float[] k, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
+        // acc layout: per local query, the `heads` heads are contiguous (head h at local*heads*headDim +
+        // h*headDim), matching the qStride layout so AxpyHeads4 can write all heads of a query at once.
         int blk = q1 - q0;
-        float[] acc = ArrayPool<float>.Shared.Rent(blk * headDim);
-        Span<float> mState = stackalloc float[FlashQueryBlock];
-        Span<float> lState = stackalloc float[FlashQueryBlock];
-        Span<float> sbuf = stackalloc float[KeyChunk];
+        float[] acc = ArrayPool<float>.Shared.Rent(blk * heads * headDim);
+        Array.Clear(acc, 0, blk * heads * headDim);
+        Span<float> mState = stackalloc float[FlashQueryBlock * 4];
+        Span<float> lState = stackalloc float[FlashQueryBlock * 4];
+        Span<float> sbuf = stackalloc float[4 * KeyChunk]; // one KeyChunk score row per head
+        mState.Slice(0, blk * heads).Fill(float.NegativeInfinity);
+        lState.Slice(0, blk * heads).Clear();
 
-        ref float qr = ref q[0];
-        ref float kr = ref k[0];
-        ref float vr = ref v[0];
-
-        for (int head = 0; head < heads; head++)
+        for (int kb = 0; kb < q1; kb += KeyChunk)
         {
-            int headOff = head * headDim;
-            Array.Clear(acc, 0, blk * headDim);
-            mState.Slice(0, blk).Fill(float.NegativeInfinity);
-            lState.Slice(0, blk).Clear();
-
-            for (int kb = 0; kb < q1; kb += KeyChunk)
+            int kEnd = Math.Min(kb + KeyChunk, q1);
+            for (int local = 0; local < blk; local++)
             {
-                int kEnd = Math.Min(kb + KeyChunk, q1);
-                for (int local = 0; local < blk; local++)
+                int qi = q0 + local;
+                if (kb > qi) continue;                  // whole chunk is causally masked for this query
+                int jHi = Math.Min(kEnd, qi + 1);
+                int cnt = jHi - kb;
+                int qb = qi * qStride;                  // head h of this query is at qb + h*headDim
+                int accLocal = local * heads * headDim;
+
+                // Head-fused scores: each key is dotted against all 4 query heads in one pass (k read once).
+                for (int jj = 0; jj < cnt; jj++)
                 {
-                    int qi = q0 + local;
-                    if (kb > qi) continue;                 // whole chunk is causally masked for this query
-                    int jHi = Math.Min(kEnd, qi + 1);
-                    int cnt = jHi - kb;
-                    int qb = qi * qStride + headOff;
+                    ScoreHeads4(q, qb, k, (kb + jj) * kvStride, headDim, scale, out float s0, out float s1, out float s2, out float s3);
+                    sbuf[0 * KeyChunk + jj] = s0;
+                    sbuf[1 * KeyChunk + jj] = s1;
+                    sbuf[2 * KeyChunk + jj] = s2;
+                    sbuf[3 * KeyChunk + jj] = s3;
+                }
 
-                    for (int jj = 0; jj < cnt; jj++)
-                    {
-                        sbuf[jj] = DotFma(ref qr, qb, ref kr, (kb + jj) * kvStride, headDim) * scale;
-                    }
-
-                    var s = sbuf.Slice(0, cnt);
+                // Per head: vectorized exp over the chunk + online-softmax bookkeeping, rescaling acc.
+                for (int head = 0; head < heads; head++)
+                {
+                    var s = sbuf.Slice(head * KeyChunk, cnt);
                     float bmax = TensorPrimitives.Max(s);
-                    float mPrev = mState[local];
+                    int st = local * heads + head;
+                    float mPrev = mState[st];
                     float mNew = MathF.Max(mPrev, bmax);
 
-                    TensorPrimitives.Subtract(s, mNew, s);  // s -= mNew
-                    TensorPrimitives.Exp(s, s);             // s = exp(s - mNew)  (vectorized)
+                    TensorPrimitives.Subtract(s, mNew, s);
+                    TensorPrimitives.Exp(s, s);             // s = exp(s - mNew), vectorized
                     float psum = TensorPrimitives.Sum(s);
                     float corr = float.IsNegativeInfinity(mPrev) ? 0f : MathF.Exp(mPrev - mNew);
 
-                    lState[local] = lState[local] * corr + psum;
-                    int accBase = local * headDim;
+                    lState[st] = lState[st] * corr + psum;
                     if (corr != 1f)
                     {
-                        ScaleInPlaceFma(acc, accBase, corr, headDim);   // rescale prior contributions to new max
+                        ScaleInPlaceFma(acc, accLocal + head * headDim, corr, headDim);
                     }
-                    for (int jj = 0; jj < cnt; jj++)
-                    {
-                        AxpyFma(acc, accBase, ref vr, (kb + jj) * kvStride, s[jj], headDim); // acc += p_jj * V_j
-                    }
-                    mState[local] = mNew;
+                    mState[st] = mNew;
+                }
+
+                // Head-fused value: each value row is read once and accumulated into all 4 heads.
+                for (int jj = 0; jj < cnt; jj++)
+                {
+                    AxpyHeads4(sbuf[0 * KeyChunk + jj], sbuf[1 * KeyChunk + jj], sbuf[2 * KeyChunk + jj], sbuf[3 * KeyChunk + jj],
+                               v, (kb + jj) * kvStride, acc, accLocal, headDim);
                 }
             }
+        }
 
-            for (int local = 0; local < blk; local++)
+        for (int local = 0; local < blk; local++)
+        {
+            for (int head = 0; head < heads; head++)
             {
-                float inv = lState[local] > 0f ? 1f / lState[local] : 0f;
-                ScaleTo(acc, local * headDim, attnOut, (q0 + local) * qStride + headOff, inv, headDim);
+                int st = local * heads + head;
+                float inv = lState[st] > 0f ? 1f / lState[st] : 0f;
+                ScaleTo(acc, st * headDim, attnOut, (q0 + local) * qStride + head * headDim, inv, headDim);
             }
         }
 
         ArrayPool<float>.Shared.Return(acc);
-    }
-
-    /// <summary>256-bit FMA dot product over <paramref name="dim"/> (a multiple of 8).</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static float DotFma(ref float a, int aOff, ref float b, int bOff, int dim)
-    {
-        var acc = Vector256<float>.Zero;
-        for (int d = 0; d < dim; d += 8)
-        {
-            acc = Fma.MultiplyAdd(Vector256.LoadUnsafe(ref a, (nuint)(aOff + d)), Vector256.LoadUnsafe(ref b, (nuint)(bOff + d)), acc);
-        }
-        return Vector256.Sum(acc);
-    }
-
-    /// <summary><c>acc += p * v</c> over <paramref name="dim"/> (FMA).</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void AxpyFma(float[] acc, int accBase, ref float v, int vOff, float p, int dim)
-    {
-        ref float ar = ref acc[0];
-        var pv = Vector256.Create(p);
-        for (int d = 0; d < dim; d += 8)
-        {
-            Fma.MultiplyAdd(pv, Vector256.LoadUnsafe(ref v, (nuint)(vOff + d)), Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d)))
-               .StoreUnsafe(ref ar, (nuint)(accBase + d));
-        }
     }
 
     /// <summary><c>acc *= corr</c> over <paramref name="dim"/> (online-softmax rescale).</summary>

--- a/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Model/Gemma3Model.cs
@@ -339,12 +339,15 @@ internal sealed class Gemma3Model
             var kq  = ArrayPool<sbyte>.Shared.Rent(seq * kvStride);
             var sK  = ArrayPool<float>.Shared.Rent(seq);
             var rsK = ArrayPool<int>.Shared.Rent(seq);
+            var vq  = ArrayPool<sbyte>.Shared.Rent(seq * kvStride);
+            var sV  = ArrayPool<float>.Shared.Rent(seq);
             try
             {
                 await ParallelExecution.ForAsync(0, seq, parallelOptions, (i, _) =>
                 {
                     QuantizeQRow(q, qu, sQ, i * qStride, i * heads, heads, headDim);
                     QuantizeKRow(k, kq, sK, rsK, i, kvStride, headDim);
+                    QuantizeVRow(v, vq, sV, i, kvStride, headDim);
                     return ValueTask.CompletedTask;
                 }).ConfigureAwait(false);
 
@@ -353,7 +356,7 @@ internal sealed class Gemma3Model
                 {
                     int q0 = b * FlashQueryBlock;
                     int q1 = Math.Min(q0 + FlashQueryBlock, seq);
-                    FlashAttentionBlockInt8(qu, sQ, kq, sK, rsK, v, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
+                    FlashAttentionBlockInt8(qu, sQ, kq, sK, rsK, vq, sV, attnOut, q0, q1, headDim, qStride, kvStride, heads, scale);
                     return ValueTask.CompletedTask;
                 }).ConfigureAwait(false);
             }
@@ -364,6 +367,8 @@ internal sealed class Gemma3Model
                 ArrayPool<sbyte>.Shared.Return(kq);
                 ArrayPool<float>.Shared.Return(sK);
                 ArrayPool<int>.Shared.Return(rsK);
+                ArrayPool<sbyte>.Shared.Return(vq);
+                ArrayPool<float>.Shared.Return(sV);
             }
             return;
         }
@@ -426,6 +431,22 @@ internal sealed class Gemma3Model
             sum += v;
         }
         rsK[i] = sum;
+    }
+
+    /// <summary>Quantizes value row <paramref name="i"/> to symmetric int8 with a per-row scale, so the
+    /// value matmul reads V at one byte/element (4x less memory). The fp probability folds the scale in.</summary>
+    private static void QuantizeVRow(float[] v, sbyte[] vq, float[] sV, int i, int kvStride, int headDim)
+    {
+        int b = i * kvStride;
+        float amax = 0f;
+        for (int d = 0; d < headDim; d++) amax = MathF.Max(amax, MathF.Abs(v[b + d]));
+        float sc = amax > 0 ? amax / 127f : 1f;
+        float inv = 1f / sc;
+        sV[i] = sc;
+        for (int d = 0; d < headDim; d++)
+        {
+            vq[b + d] = (sbyte)Math.Clamp((int)MathF.Round(v[b + d] * inv), -127, 127);
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -625,7 +646,7 @@ internal sealed class Gemma3Model
     /// fp32, and attention is memory-bound). Softmax and the value matmul stay fp32.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private static void FlashAttentionBlockInt8(byte[] qu, float[] sQ, sbyte[] kq, float[] sK, int[] rsK, float[] v, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
+    private static void FlashAttentionBlockInt8(byte[] qu, float[] sQ, sbyte[] kq, float[] sK, int[] rsK, sbyte[] vq, float[] sV, float[] attnOut, int q0, int q1, int headDim, int qStride, int kvStride, int heads, float scale)
     {
         int blk = q1 - q0;
         float[] acc = ArrayPool<float>.Shared.Rent(blk * heads * headDim);
@@ -683,8 +704,10 @@ internal sealed class Gemma3Model
 
                 for (int jj = 0; jj < cnt; jj++)
                 {
-                    AxpyHeads4(sbuf[0 * KeyChunk + jj], sbuf[1 * KeyChunk + jj], sbuf[2 * KeyChunk + jj], sbuf[3 * KeyChunk + jj],
-                               v, (kb + jj) * kvStride, acc, accLocal, headDim);
+                    int key = kb + jj;
+                    float sv = sV[key]; // per-row value scale folded into each head's probability
+                    AxpyHeads4Int8(sbuf[0 * KeyChunk + jj] * sv, sbuf[1 * KeyChunk + jj] * sv, sbuf[2 * KeyChunk + jj] * sv, sbuf[3 * KeyChunk + jj] * sv,
+                                   vq, key * kvStride, acc, accLocal, headDim);
                 }
             }
         }
@@ -700,6 +723,32 @@ internal sealed class Gemma3Model
         }
 
         ArrayPool<float>.Shared.Return(acc);
+    }
+
+    /// <summary>Value accumulation for all 4 heads from an int8 value row: widens 8 int8 values to float
+    /// and FMAs <c>weight_head * v</c> into each head's accumulator. V is read once (1 byte/element) for
+    /// all four heads.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AxpyHeads4Int8(float w0, float w1, float w2, float w3, sbyte[] vq, int vBase, float[] acc, int accBase, int headDim)
+    {
+        ref sbyte vr = ref vq[0];
+        ref float ar = ref acc[0];
+        var p0 = Vector256.Create(w0);
+        var p1 = Vector256.Create(w1);
+        var p2 = Vector256.Create(w2);
+        var p3 = Vector256.Create(w3);
+        int o1 = accBase + headDim, o2 = accBase + 2 * headDim, o3 = accBase + 3 * headDim;
+        for (int d = 0; d < headDim; d += 8)
+        {
+            // Read exactly 8 int8 values (a long) and sign-extend to 8 int32 -> 8 float (no over-read).
+            long bits = Unsafe.ReadUnaligned<long>(ref Unsafe.As<sbyte, byte>(ref Unsafe.Add(ref vr, vBase + d)));
+            var vi = Avx2.ConvertToVector256Int32(Vector128.CreateScalarUnsafe(bits).AsSByte());
+            var vf = Vector256.ConvertToSingle(vi);
+            Fma.MultiplyAdd(p0, vf, Vector256.LoadUnsafe(ref ar, (nuint)(accBase + d))).StoreUnsafe(ref ar, (nuint)(accBase + d));
+            Fma.MultiplyAdd(p1, vf, Vector256.LoadUnsafe(ref ar, (nuint)(o1 + d))).StoreUnsafe(ref ar, (nuint)(o1 + d));
+            Fma.MultiplyAdd(p2, vf, Vector256.LoadUnsafe(ref ar, (nuint)(o2 + d))).StoreUnsafe(ref ar, (nuint)(o2 + d));
+            Fma.MultiplyAdd(p3, vf, Vector256.LoadUnsafe(ref ar, (nuint)(o3 + d))).StoreUnsafe(ref ar, (nuint)(o3 + d));
+        }
     }
 
     /// <summary>Int8 VNNI scores for the four GQA query heads against one shared key: <c>vpdpbusd</c> of the

--- a/SentenceTransformers.Harrier.Small.Pure/src/Numerics/Ops.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/Numerics/Ops.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using SentenceTransformers;
@@ -87,7 +88,7 @@ internal static class Ops
     /// <summary>
     /// Gemma's GeGLU feed-forward combination: <c>out = gelu_tanh(gate) * up</c>, written into
     /// <paramref name="gate"/> in place. <paramref name="gate"/> and <paramref name="up"/> have the
-    /// same length.
+    /// same length. Scalar reference kept for tests; the hot path uses <see cref="GeGluAsync"/>.
     /// </summary>
     public static void GeGluInPlace(Span<float> gate, ReadOnlySpan<float> up)
     {
@@ -98,6 +99,49 @@ internal static class Ops
             float inner = c * (v + 0.044715f * v * v * v);
             float gelu = 0.5f * v * (1f + MathF.Tanh(inner));
             gate[i] = gelu * up[i];
+        }
+    }
+
+    /// <summary>
+    /// Vectorized, row-parallel GeGLU: identical math to <see cref="GeGluInPlace"/> but computed with
+    /// SIMD <see cref="TensorPrimitives"/> (including a vectorized tanh) over each row, parallelized over
+    /// the <paramref name="rows"/> sequence positions. The old scalar path spent most of the FF time in
+    /// per-element <see cref="MathF.Tanh"/>; this keeps the row (a few KB) cache-resident across the
+    /// elementwise passes. Results match the scalar form to float tolerance (tanh reassociation only).
+    /// </summary>
+    public static Task GeGluAsync(float[] gate, float[] up, int rows, int dim, ParallelOptions parallelOptions)
+    {
+        return ParallelExecution.ForAsync(0, rows, parallelOptions, (r, _) =>
+        {
+            GeGluRow(gate.AsSpan(r * dim, dim), up.AsSpan(r * dim, dim));
+            return ValueTask.CompletedTask;
+        });
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void GeGluRow(Span<float> gate, ReadOnlySpan<float> up)
+    {
+        const float c = 0.7978845608028654f; // sqrt(2/pi)
+        int dim = gate.Length;
+        float[] tmp = ArrayPool<float>.Shared.Rent(dim);
+        try
+        {
+            var t = tmp.AsSpan(0, dim);
+            // t = inner = c * x * (1 + 0.044715 x^2)   (== c*(x + 0.044715 x^3), same as the scalar form)
+            TensorPrimitives.Multiply(gate, gate, t);   // t = x^2
+            TensorPrimitives.Multiply(t, 0.044715f, t);  // t = 0.044715 x^2
+            TensorPrimitives.Add(t, 1f, t);              // t = 1 + 0.044715 x^2
+            TensorPrimitives.Multiply(t, gate, t);       // t = x (1 + 0.044715 x^2)
+            TensorPrimitives.Multiply(t, c, t);          // t = inner
+            TensorPrimitives.Tanh(t, t);                 // t = tanh(inner)
+            TensorPrimitives.Add(t, 1f, t);              // t = 1 + tanh
+            TensorPrimitives.Multiply(t, 0.5f, t);       // t = 0.5 (1 + tanh)
+            TensorPrimitives.Multiply(t, gate, t);       // t = gelu(x) = 0.5 x (1 + tanh(inner))
+            TensorPrimitives.Multiply(t, up, gate);      // gate = gelu(x) * up
+        }
+        finally
+        {
+            ArrayPool<float>.Shared.Return(tmp);
         }
     }
 

--- a/SentenceTransformers.Harrier.Small.Pure/src/SentenceEncoder.cs
+++ b/SentenceTransformers.Harrier.Small.Pure/src/SentenceEncoder.cs
@@ -37,6 +37,12 @@ namespace SentenceTransformers.Harrier.Small.Pure
 
         private readonly Gemma3Model _model;
 
+        /// <summary>Parallelism used by the parameterless <see cref="EncodeAsync(string[], CancellationToken)"/>
+        /// document path. Defaults to single-threaded (1) when the caller did not supply a
+        /// <c>parallelOptions</c> at construction; pass one to <see cref="CreateAsync"/> / <see cref="LoadAsync"/>
+        /// (e.g. <c>MaxDegreeOfParallelism = Environment.ProcessorCount</c>) to fan encoding across cores.</summary>
+        private readonly ParallelOptions _defaultParallelOptions;
+
         public TokenizerBase Tokenizer { get; }
         private readonly HarrierSmallPureTokenizer _tokenizer;
 
@@ -63,6 +69,10 @@ namespace SentenceTransformers.Harrier.Small.Pure
         /// (float32) is the default and exactly matches the reference; <see cref="Quantization.Int8"/> and
         /// <see cref="Quantization.Int4"/> shrink the in-memory footprint ~4x / ~8x respectively.</param>
         /// <param name="reportProgress">Optional download progress callback (~2 Hz).</param>
+        /// <param name="parallelOptions">Concurrency for loading/quantization <b>and</b> the default used by
+        /// the <see cref="EncodeAsync(string[], CancellationToken)"/> document path. When <c>null</c>, loading
+        /// uses half the cores and encoding runs single-threaded (<c>MaxDegreeOfParallelism = 1</c>); pass
+        /// <c>new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }</c> to encode on all cores.</param>
         public static async Task<SentenceEncoder> CreateAsync(
             string weightsUrl = null,
             string downloadToPath = null,
@@ -70,16 +80,10 @@ namespace SentenceTransformers.Harrier.Small.Pure
             Action<DownloadProgress> reportProgress = null,
             ParallelOptions parallelOptions = null)
         {
-
-            parallelOptions ??= new ParallelOptions()
-            {
-                MaxDegreeOfParallelism = Environment.ProcessorCount / 2
-            };
-
             var path = downloadToPath ?? Path.Combine(Path.GetTempPath(), "SentenceTransformers.Harrier.Small.Pure", "harrier-small.safetensors");
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 
-            await DownloadFileAsync(weightsUrl ?? DefaultWeightsUrl, path, reportProgress, parallelOptions.CancellationToken).ConfigureAwait(false);
+            await DownloadFileAsync(weightsUrl ?? DefaultWeightsUrl, path, reportProgress, parallelOptions?.CancellationToken ?? default).ConfigureAwait(false);
             return await LoadAsync(path, quantization: quantization, parallelOptions: parallelOptions).ConfigureAwait(false);
         }
 
@@ -94,26 +98,27 @@ namespace SentenceTransformers.Harrier.Small.Pure
             Quantization quantization = Quantization.None,
             ParallelOptions parallelOptions = null)
         {
-            parallelOptions ??= new ParallelOptions()
-            {
-                MaxDegreeOfParallelism = Environment.ProcessorCount / 2
-            };
-
             if (string.IsNullOrWhiteSpace(safetensorsPath))
             {
                 throw new ArgumentException("Weights path is required.", nameof(safetensorsPath));
             }
 
-            var model = await Gemma3Model.LoadAsync(safetensorsPath, new Gemma3Config(), quantization, parallelOptions).ConfigureAwait(false);
+            // Loading/quantization concurrency: use the caller's options, else half the cores (unchanged).
+            var loadOptions = parallelOptions ?? new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount / 2 };
+            // Encode-time default: the caller's options when supplied, otherwise single-threaded.
+            var encodeDefault = parallelOptions ?? new ParallelOptions { MaxDegreeOfParallelism = 1 };
+
+            var model = await Gemma3Model.LoadAsync(safetensorsPath, new Gemma3Config(), quantization, loadOptions).ConfigureAwait(false);
             var tokenizer = LoadTokenizer(tokenizerJsonPath, GetMaxChunkLength());
-            return new SentenceEncoder(model, tokenizer);
+            return new SentenceEncoder(model, tokenizer, encodeDefault);
         }
 
-        private SentenceEncoder(Gemma3Model model, HarrierSmallPureTokenizer tokenizer)
+        private SentenceEncoder(Gemma3Model model, HarrierSmallPureTokenizer tokenizer, ParallelOptions defaultParallelOptions)
         {
             _model = model;
             _tokenizer = tokenizer;
             Tokenizer = tokenizer;
+            _defaultParallelOptions = defaultParallelOptions ?? new ParallelOptions { MaxDegreeOfParallelism = 1 };
         }
 
         /// <summary>Name of the tokenizer copied next to the app. Prefixed with the model name so it
@@ -153,8 +158,12 @@ namespace SentenceTransformers.Harrier.Small.Pure
             throw new FileNotFoundException($"tokenizer.json was not found embedded in the assembly or at Resources/{TokenizerFileName}.");
         }
 
-        public Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default) => 
-            EncodeAsync(sentences, new ParallelOptions() { CancellationToken = cancellationToken });
+        public Task<float[][]> EncodeAsync(string[] sentences, CancellationToken cancellationToken = default) =>
+            EncodeAsync(sentences, new ParallelOptions
+            {
+                MaxDegreeOfParallelism = _defaultParallelOptions.MaxDegreeOfParallelism,
+                CancellationToken      = cancellationToken,
+            });
 
         /// <summary>Encodes a batch of texts into embeddings. Each input must fit in
         /// <see cref="MaxChunkLength"/> tokens; for longer text use the <c>ChunkAndEncode*</c> helpers.</summary>

--- a/SentenceTransformers.sln
+++ b/SentenceTransformers.sln
@@ -34,6 +34,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Harrie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Harrier.Small.Pure", "SentenceTransformers.Harrier.Small.Pure\SentenceTransformers.Harrier.Small.Pure.csproj", "{2DF263BC-594A-42E9-B8F5-6AF6626A0013}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SentenceTransformers.Benchmark.Sweep", "SentenceTransformers.Benchmark.Sweep\SentenceTransformers.Benchmark.Sweep.csproj", "{5C421C31-B967-42D0-A796-CE6E57C2CA7A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -188,6 +190,18 @@ Global
 		{2DF263BC-594A-42E9-B8F5-6AF6626A0013}.Release|x64.Build.0 = Release|Any CPU
 		{2DF263BC-594A-42E9-B8F5-6AF6626A0013}.Release|x86.ActiveCfg = Release|Any CPU
 		{2DF263BC-594A-42E9-B8F5-6AF6626A0013}.Release|x86.Build.0 = Release|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Debug|x64.Build.0 = Debug|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Debug|x86.Build.0 = Debug|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Release|x64.ActiveCfg = Release|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Release|x64.Build.0 = Release|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Release|x86.ActiveCfg = Release|Any CPU
+		{5C421C31-B967-42D0-A796-CE6E57C2CA7A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/scripts/harrier_scaling_bench.py
+++ b/scripts/harrier_scaling_bench.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Token-count scalability sweep for Harrier Small using the original PyTorch /
+sentence-transformers implementation, so it can be compared apples-to-apples with
+the C# pure and ONNX builds.
+
+Replays the byte-identical calibrated inputs written by the C# harness
+(/tmp/harrier_scaling_inputs.json), encodes each on CPU through the public
+SentenceTransformer.encode() path, and records the elapsed ms per encode at each
+token count. Writes /tmp/harrier_scaling_python.json for merging with the C# results.
+
+Usage:
+    python scripts/harrier_scaling_bench.py
+"""
+import json
+import os
+import time
+import statistics
+
+import torch
+from sentence_transformers import SentenceTransformer
+
+MODEL_ID = "microsoft/harrier-oss-v1-270m"
+INPUTS = "/tmp/harrier_scaling_inputs.json"
+OUT = "/tmp/harrier_scaling_python.json"
+
+
+def iterations_for(tokens: int) -> int:
+    if tokens <= 256:
+        return 7
+    if tokens <= 512:
+        return 5
+    if tokens <= 1024:
+        return 3
+    if tokens <= 2048:
+        return 2
+    return 1
+
+
+def main():
+    # Match the C# run: CPU only, all 4 cores.
+    torch.set_num_threads(os.cpu_count() or 4)
+    print(f"torch {torch.__version__}, threads={torch.get_num_threads()}, device=cpu")
+
+    with open(INPUTS, encoding="utf-8") as f:
+        inputs = json.load(f)
+
+    print(f"Loading {MODEL_ID} on CPU ...")
+    model = SentenceTransformer(MODEL_ID, device="cpu")
+    model.eval()
+    tok = model.tokenizer
+
+    results = []
+    print()
+    print("=== Harrier Small (PyTorch / sentence-transformers, CPU fp32) ===")
+    for item in inputs:
+        text = item["text"]
+        target = item["target"]
+        cs_tokens = item["tokens"]
+        # Token count as the HF tokenizer sees it (should match the C# Gemma count).
+        py_tokens = len(tok(text)["input_ids"])
+
+        # Warmup.
+        with torch.no_grad():
+            model.encode([text], normalize_embeddings=True, show_progress_bar=False)
+
+        n = iterations_for(cs_tokens)
+        samples = []
+        for _ in range(n):
+            t0 = time.perf_counter()
+            with torch.no_grad():
+                model.encode([text], normalize_embeddings=True, show_progress_bar=False)
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        samples.sort()
+        median = samples[len(samples) // 2]
+        print(f"  {cs_tokens:5d} tokens (py={py_tokens:5d}): {median:9.1f} ms  "
+              f"(median of {n}, min {samples[0]:.1f})")
+        results.append({
+            "target": target,
+            "tokens": cs_tokens,
+            "py_tokens": py_tokens,
+            "python_ms": median,
+        })
+
+    with open(OUT, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+    print()
+    print(f"Wrote Python results -> {OUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Investigates Harrier Small scalability vs token count, then optimizes the pure-managed encoder until its **Int8** path is effectively at parity with the ONNX builds, and adds a reusable multi-model sweep benchmark. All changes are correctness-gated against the PyTorch golden reference.

## Optimizations to `SentenceTransformers.Harrier.Small.Pure`

Profiling the Int8 forward (per stage, all cores) found the costs and several dead ends. Net: the **4096-token attention term went from ~10,500 ms → ~2,100 ms (~5×)** and the **Pure-Int8 / ONNX-Int8 gap at 4096 went from ~2.0× → ~1.13×**, with pure Int8 now **faster than ONNX Int8 at ≤256 tokens** and **faster than ONNX Q4F16 at 4096**.

- **Vectorized + parallelized GeGLU** — was a scalar `MathF.Tanh` loop (~40% of time at 512 tokens); now `TensorPrimitives` (vectorized tanh), row-parallel. ~25× on that stage.
- **Block-flash attention** — chunked online softmax (no seq×seq score matrix materialized), large query block for K/V reuse, 4 GQA query heads fused per key, vectorized `exp` per chunk. Also makes the encoder run in O(seq) attention memory — it completes the **full 32768-token window where ONNX Int8 OOMs** (ONNX CPU `GroupQueryAttention` materializes the full score tensor, ~16 GB).
- **int8 / VNNI attention scores** — Q→uint8 / K→int8 per-row quant + `vpdpbusd` dot (4× less K memory; attention is memory-bound). Value stays fp32 (int8 V was measured slower — V is cache-resident — and reverted).
- **AVX-512 (512-bit) kernels** with `IsSupported` bool-flag switching (JIT-constant; 256-bit / `Vector<T>` fallback dead-code-eliminated on lesser hardware): 512-bit VNNI scores + 512-bit FMA value/scale.
- **Register-blocked value GEMM** — a 4-head × 64-column output tile held in 16 zmm accumulators across the key chunk (acc written once per tile, not per key). The biggest single win: roughly **halved attention** at 2k–4k.

Documented in `SentenceTransformers.Benchmark/HARRIER-SCALING.md` (journey, per-stage profiles, parity assessment, reproduce commands).

## Configurable default parallelism

`Harrier.Small.Pure.SentenceEncoder.CreateAsync`/`LoadAsync` now accept a default `ParallelOptions` that the convenience `EncodeAsync(string[])` document path uses for its core count, **falling back to single-threaded (1) when none is supplied** (default behavior unchanged). The explicit `EncodeAsync(string[], ParallelOptions)` overload is unchanged.

## New project: `SentenceTransformers.Benchmark.Sweep`

Token-count scalability sweep across **all** encoder models (MiniLM, ArcticXs, Qwen3, Harrier Small Pure fp32/Int8, Harrier Small ONNX Q4F16/Int8, Harrier Medium). Sweeps **128 → each model's own context window**, reports **time + throughput (MB/s in/out, tok/s)**, and tolerates per-point failures (e.g. the 0.6B ONNX graphs OOM at 32k). Added to `SentenceTransformers.sln`.

```
dotnet run -c Release --project SentenceTransformers.Benchmark.Sweep            # all models
dotnet run -c Release --project SentenceTransformers.Benchmark.Sweep -- harrier # substring filter
```

## Benchmark/diagnostic additions (`SentenceTransformers.Benchmark`)

New commands: `harrier-scaling` (128–4096, 4 impls, max cores), `harrier-scaling-long` (4096–32768, Pure vs ONNX Int8), `harrier-profile <maxDop> [quant]` (per-stage profile), `harrier-verify` / `harrier-verify-fma` (correctness gates), `harrier-scaling-pure <quant>`. Plus an opt-in `ForwardProfile` per-stage timer and `scripts/harrier_scaling_bench.py` (PyTorch reference).

## Correctness

fp32 cosine ≈ 0.9999 vs the PyTorch golden reference throughout; Int8 ≈ 0.9938 avg / 0.984 min — unchanged by the int8-attention/AVX-512/blocked-GEMM kernels and well above the 0.95 model-card threshold.

https://claude.ai/code/session_01RLqVL6KjmpnFkse2iFVSMu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLqVL6KjmpnFkse2iFVSMu)_